### PR TITLE
[add] ユーザー情報取得、削除APIを作成しました

### DIFF
--- a/backend-go/srcs/auth/login.go
+++ b/backend-go/srcs/auth/login.go
@@ -36,17 +36,20 @@ func Login(reqContext *gin.Context) {
 	var loginInput LoginInput
 
 	if err := reqContext.ShouldBindJSON(&loginInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
 		return
 	}
 	if err := loginInput.validate(); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+		reqContext.Error(err)
 		return
 	}
 
 	jwtTokenString, err := models.FetchUserAndGenerateJWTTokenString(loginInput.Username, loginInput.Email, loginInput.Password)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to generate JWT"})
+		reqContext.Error(err)
 		return
 	}
 

--- a/backend-go/srcs/auth/register.go
+++ b/backend-go/srcs/auth/register.go
@@ -30,7 +30,8 @@ func RegisterUser(reqContext *gin.Context) {
 	var registerInput RegisterInput
 
 	if err := reqContext.ShouldBindJSON(&registerInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
 		return
 	}
 
@@ -46,7 +47,8 @@ func RegisterUser(reqContext *gin.Context) {
 
 	registerUser, err := registerUser.CreateUser()
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to create user"})
+		reqContext.Error(err)
 		return
 	}
 

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -23,6 +23,7 @@ func main() {
 	settingRoutes := router.Group("/settings")
 	settingRoutes.Use(middlewares.JWTValidationMiddleware())
 	settingRoutes.PUT("/user", models.ChangeUserInfo)
+	settingRoutes.DELETE("/user", models.DeleteUser)
 
 	router.Run(":8080")
 }

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	settingRoutes := router.Group("/settings")
 	settingRoutes.Use(middlewares.JWTValidationMiddleware())
+	settingRoutes.GET("/user", models.GetUserInfo)
 	settingRoutes.PUT("/user", models.ChangeUserInfo)
 	settingRoutes.DELETE("/user", models.DeleteUser)
 

--- a/backend-go/srcs/middlewares/jwt.go
+++ b/backend-go/srcs/middlewares/jwt.go
@@ -16,7 +16,8 @@ func JWTValidationMiddleware() gin.HandlerFunc {
 	return func(reqContext *gin.Context) {
 		err := token.ValidateJWTToken(reqContext)
 		if err != nil {
-			reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+			reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to validate JWT"})
+			reqContext.Error(err)
 			reqContext.Abort()
 			return
 		}

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -165,3 +165,31 @@ func ChangeUserInfo(reqContext *gin.Context) {
 		"data": user.PrepareOutput(),
 	})
 }
+
+func DeleteUser(reqContext *gin.Context) {
+	/*
+		DBからユーザーを削除する関数。
+	*/
+	userId, err := token.ExtractUserIdFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	user := &TUser{}
+	err = DB.First(&user, userId).Error
+	if err != nil {
+		reqContext.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = DB.Delete(user).Error
+	if err != nil {
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	reqContext.JSON(http.StatusOK, gin.H{
+		"status": "success",
+	})
+}

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -114,7 +114,7 @@ func GetUserInfo(reqContext *gin.Context) {
 	}
 
 	reqContext.JSON(http.StatusOK, gin.H{
-		"user": user,
+		"user": user.PrepareOutput(),
 	})
 }
 

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -99,6 +99,25 @@ func FetchUserAndGenerateJWTTokenString(username string, email string, password 
 	return jwtTokenString, nil
 }
 
+func GetUserInfo(reqContext *gin.Context) {
+	userId, err := token.ExtractUserIdFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	user := &TUser{}
+	err = DB.First(&user, userId).Error
+	if err != nil {
+		reqContext.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	reqContext.JSON(http.StatusOK, gin.H{
+		"user": user,
+	})
+}
+
 type ChangeUserInfoInput struct {
 	/*
 		登録時にリクエストからJSONデータを抽出するための構造体。

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -100,16 +100,21 @@ func FetchUserAndGenerateJWTTokenString(username string, email string, password 
 }
 
 func GetUserInfo(reqContext *gin.Context) {
+	/*
+		ユーザーの情報を取得する関数。
+	*/
 	userId, err := token.ExtractUserIdFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to get user id from token"})
+		reqContext.Error(err)
 		return
 	}
 
 	user := &TUser{}
 	err = DB.First(&user, userId).Error
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.Error(err)
 		return
 	}
 
@@ -159,24 +164,28 @@ func ChangeUserInfo(reqContext *gin.Context) {
 	*/
 	userId, err := token.ExtractUserIdFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to get user id from token"})
+		reqContext.Error(err)
 		return
 	}
 
 	user := &TUser{}
 	err = DB.First(&user, userId).Error
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.Error(err)
 		return
 	}
 
 	var changeUserInfoInput ChangeUserInfoInput
 	if err := reqContext.ShouldBindJSON(&changeUserInfoInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
 		return
 	}
 	if err := user.UpdateUser(changeUserInfoInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to update user"})
+		reqContext.Error(err)
 		return
 	}
 
@@ -191,20 +200,23 @@ func DeleteUser(reqContext *gin.Context) {
 	*/
 	userId, err := token.ExtractUserIdFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to get user id from token"})
+		reqContext.Error(err)
 		return
 	}
 
 	user := &TUser{}
 	err = DB.First(&user, userId).Error
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.Error(err)
 		return
 	}
 
 	err = DB.Delete(user).Error
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete user"})
+		reqContext.Error(err)
 		return
 	}
 


### PR DESCRIPTION
**説明**
ユーザー情報を取得するAPIと削除するAPIを作成しました。

**確認方法**
#18 と同様にpostmanを使用してテストしてください。
1. 「登録」でユーザー作成
2.「ログイン」でJWTトークン取得
3.「ユーザー情報取得」でユーザー情報を取得
4.「ユーザー削除」でユーザーを削除
postmanのドキュメントにも書いていますが、ユーザー情報取得、削除時にJSONデータは必要ありません。

削除した後、実際にDBから消えているかを確認したい場合はdb-mysqlコンテナで以下のコードを順に実行してください。
```
$ mysql -u root -p
-> .envのMYSQL_ROOT_PASSWORDを入力
> use matcha;
> select * from t_users;
```