### PR TITLE
[add] backendの本番環境用の設定を追加しました。

### DIFF
--- a/backend-go/.gitignore
+++ b/backend-go/.gitignore
@@ -25,3 +25,6 @@
 go.work
 
 # End of https://www.toptal.com/developers/gitignore/api/go
+
+# mine
+./logs/*

--- a/backend-go/srcs/go.mod
+++ b/backend-go/srcs/go.mod
@@ -4,6 +4,7 @@ go 1.23.6
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gin-contrib/cors v1.7.3
 	github.com/gin-gonic/gin v1.10.0
 	golang.org/x/crypto v0.33.0
 	gorm.io/driver/mysql v1.5.7
@@ -26,6 +27,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/backend-go/srcs/go.mod
+++ b/backend-go/srcs/go.mod
@@ -4,7 +4,6 @@ go 1.23.6
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/gin-contrib/cors v1.7.3
 	github.com/gin-gonic/gin v1.10.0
 	golang.org/x/crypto v0.33.0
 	gorm.io/driver/mysql v1.5.7
@@ -27,12 +26,13 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.14.0 // indirect
@@ -40,5 +40,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -23,8 +23,10 @@ func main() {
 		router = gin.New()
 		router.Use(utils.ProductionLogger())
 		router.Use(gin.Recovery())
+		gin.SetMode(gin.ReleaseMode)
 	} else {
 		router = gin.Default()
+		gin.SetMode(gin.DebugMode)
 	}
 
 	router.GET("/health", func(reqContext *gin.Context) {

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"net/http"
+	"os"
 	"srcs/auth"
 	"srcs/middlewares"
 	"srcs/models"
 	"srcs/post"
+	"srcs/utils"
 
 	"github.com/gin-gonic/gin"
 )
@@ -16,7 +18,14 @@ func main() {
 	*/
 	models.ConnectDataBase()
 
-	router := gin.Default()
+	var router *gin.Engine
+	if os.Getenv("ENVIRONMENT") == "production" {
+		router = gin.New()
+		router.Use(utils.ProductionLogger())
+		router.Use(gin.Recovery())
+	} else {
+		router = gin.Default()
+	}
 
 	router.GET("/health", func(reqContext *gin.Context) {
 		reqContext.JSON(http.StatusOK, gin.H{

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -24,6 +24,12 @@ func main() {
 		router.Use(utils.ProductionLogger())
 		router.Use(gin.Recovery())
 		gin.SetMode(gin.ReleaseMode)
+		//router.Use(cors.New(cors.Config{
+		//	AllowOrigins:     []string{os.Getenv("ALLOWED_ORIGINS")}, // 本番環境のドメインのみ許可
+		//	AllowMethods:     []string{"GET", "POST", "PUT", "DELETE"},
+		//	AllowHeaders:     []string{"Content-Type", "Authorization"},
+		//	AllowCredentials: true,
+		//}))
 	} else {
 		router = gin.Default()
 		gin.SetMode(gin.DebugMode)

--- a/backend-go/srcs/models/setup.go
+++ b/backend-go/srcs/models/setup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -42,4 +43,16 @@ func ConnectDataBase() {
 	DB.AutoMigrate(&TInterestTag{})
 	DB.AutoMigrate(&TPost{})
 	DB.AutoMigrate(&TPostImageURL{})
+
+	if os.Getenv("ENVIRONMENT") == "production" {
+		mysqlDB, err := DB.DB()
+		if err != nil {
+			log.Fatal("DB取得失敗:", err)
+		}
+		mysqlDB.SetMaxIdleConns(10)
+		mysqlDB.SetMaxOpenConns(100)
+		mysqlDB.SetConnMaxLifetime(time.Hour)
+
+		fmt.Println("DB接続成功！")
+	}
 }

--- a/backend-go/srcs/utils/production_log.go
+++ b/backend-go/srcs/utils/production_log.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"github.com/gin-gonic/gin"
+	"log"
+	"os"
+	"time"
+)
+
+func ProductionLogger() gin.HandlerFunc {
+	if err := os.MkdirAll("logs/gin", 0755); err != nil {
+		log.Fatal("Error creating log directory.", err)
+	}
+
+	logFile, err := os.OpenFile("logs/gin/access.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal("Can't open log file.", err)
+	}
+	logger := log.New(logFile, "[production] ", 11)
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		logger.Printf("%s | %s | %d | %s | %s",
+			start.Format("2006/01/02 15:04:05"),
+			c.Request.Method,
+			c.Writer.Status(),
+			c.Request.URL.Path,
+			time.Since(start))
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,6 @@
+services:
+  backend-go:
+    volumes:
+      - ./backend-go/logs/:/usr/src/app/logs
+    env_file:
+      - .env.prod


### PR DESCRIPTION
**説明**
本番環境用の設定を追加しました。
・httpステータスログを制御する(ログファイルに出力)
・本番環境はginをreleaseモードにすることでginの最小限のログが出る
・現時点ではコメントアウトしているが、許可するオリジンを設定(フロントと通信できるようになったら確認)
・DBに対する接続プールを設定(多すぎるアクセスを制御)

**確認方法**
.env.prodファイルを作成し、
```
docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
```
で起動したのち、postmanから「ユーザー登録」などを行なって
・ログがログファイル(backend-go/logs/gin/)に出ていること
・ginのログ(backend-goコンテナのログ)が最小になっていること
を確認してください。
他2つはコードから確認してください。

**今後の展望**
DBの本番環境設定はデプロイツールと深く関係するのでデプロイ時に考えます。
フロントエンドの本番環境設定の作成をお願いしたいです！