### PR TITLE
[add] 投稿一覧取得のAPIを作成しました。

### DIFF
--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	postRoutes := router.Group("/posts")
 	postRoutes.POST("/submit", post.Submit)
+	postRoutes.GET("/retrieve", post.Retrieve)
 
 	settingRoutes := router.Group("/settings")
 	settingRoutes.Use(middlewares.JWTValidationMiddleware())

--- a/backend-go/srcs/models/affiliations.go
+++ b/backend-go/srcs/models/affiliations.go
@@ -6,7 +6,7 @@ type TAffiliation struct {
 	*/
 	ID     int     `gorm:"primaryKey;autoIncrement;column:id"`
 	Name   string  `gorm:"type:varchar(100);not null;unique;gorm:column:name"`
-	TUsers []TUser `gorm:"many2many:t_user_affiliations;"`
+	TUsers []TUser `gorm:"many2many:t_user_affiliations;" json:"-"`
 }
 
 func (TAffiliation) TableName() string { return "t_affiliations" }

--- a/backend-go/srcs/models/interest_tags.go
+++ b/backend-go/srcs/models/interest_tags.go
@@ -6,8 +6,8 @@ type TInterestTag struct {
 	*/
 	ID    int     `gorm:"primaryKey;autoIncrement;column:id"`
 	Name  string  `gorm:"type:varchar(100);not null;unique;gorm:column:name"`
-	Users []TUser `gorm:"many2many:t_user_interest_tags;"`
-	Posts []TPost `gorm:"many2many:t_post_interest_tags;"`
+	Users []TUser `gorm:"many2many:t_user_interest_tags;"  json:"-"`
+	Posts []TPost `gorm:"many2many:t_post_interest_tags;" json:"-"`
 }
 
 func (*TInterestTag) TableName() string { return "t_interest_tags" }

--- a/backend-go/srcs/models/pictures.go
+++ b/backend-go/srcs/models/pictures.go
@@ -5,9 +5,9 @@ type TPicture struct {
 		t_picturesテーブルの構造体
 	*/
 	ID         int    `gorm:"primaryKey;autoIncrement;column:id"`
-	UserID     int    `gorm:"type:varchar(100);not null;gorm:column:user_id"`
+	UserID     int    `gorm:"type:varchar(100);not null;gorm:column:user_id" json:"-"`
 	PictureURL string `gorm:"type:varchar(255);not null;column:picture_url"`
-	User       TUser  `gorm:"foreignkey:UserID;references:ID"`
+	User       TUser  `gorm:"foreignkey:UserID;references:ID" json:"-"`
 }
 
 func (*TPicture) TableName() string { return "t_pictures" }

--- a/backend-go/srcs/models/post_image_urls.go
+++ b/backend-go/srcs/models/post_image_urls.go
@@ -5,9 +5,9 @@ type TPostImageURL struct {
 		post_image_urlsテーブルの構造体
 	*/
 	ID           int    `gorm:"primaryKey;autoIncrement;column:id"`
-	PostID       int    `gorm:"type:int(10);not null;column:post_id"`
+	PostID       int    `gorm:"type:int(10);not null;column:post_id" json:"-"`
 	PostImageUrl string `gorm:"type:varchar(255);not null;column:post_image_url"`
-	Post         TPost  `gorm:"foreignKey:PostID;references:ID"`
+	Post         TPost  `gorm:"foreignKey:PostID;references:ID" json:"-"`
 }
 
 func (*TPostImageURL) TableName() string { return "t_post_image_urls" }

--- a/backend-go/srcs/models/posts.go
+++ b/backend-go/srcs/models/posts.go
@@ -10,7 +10,7 @@ type TPost struct {
 		postsテーブルの構造体
 	*/
 	ID           int             `gorm:"primaryKey;autoIncrement;column:id"`
-	UserID       uint            `gorm:"type:int(10);not null;column:user_id"`
+	UserID       uint            `gorm:"type:int(10);not null;column:user_id" json:"-"`
 	Text         string          `gorm:"type:varchar(30);column:text"`
 	IsDraft      bool            `gorm:"type:boolean;not null;column:is_draft"`
 	CreatedAt    time.Time       `gorm:"column:created_at"`

--- a/backend-go/srcs/models/posts.go
+++ b/backend-go/srcs/models/posts.go
@@ -15,7 +15,7 @@ type TPost struct {
 	IsDraft      bool            `gorm:"type:boolean;not null;column:is_draft"`
 	CreatedAt    time.Time       `gorm:"column:created_at"`
 	InterestTags []TInterestTag  `gorm:"many2many:t_post_interest_tags;"`
-	User         TUser           `gorm:"foreignkey:UserID;references:ID"`
+	User         TUser           `gorm:"foreignkey:UserID;references:ID" json:"-"`
 	PostImageURL []TPostImageURL `gorm:"foreignkey:PostID;references:ID"`
 }
 

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -29,8 +29,8 @@ type TUser struct {
 	UpdatedAt        time.Time      `gorm:"type:timestamp;default:CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;column:updated_at"`
 	Affiliations     []TAffiliation `gorm:"many2many:t_user_affiliations;"`
 	InterestTags     []TInterestTag `gorm:"many2many:t_user_interest_tags;"`
-	Posts            []TPost        `gorm:"foreignKey:UserID;references:ID"`
-	Pictures         []TPicture     `gorm:"foreignKey:UserID;references:ID"`
+	Posts            []TPost        `gorm:"foreignKey:UserID;references:ID" json:"-"`
+	Pictures         []TPicture     `gorm:"foreignKey:UserID;references:ID" json:"-"`
 }
 
 func (*TUser) TableName() string {

--- a/backend-go/srcs/post/retrieve.go
+++ b/backend-go/srcs/post/retrieve.go
@@ -1,0 +1,32 @@
+package post
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"srcs/models"
+	"srcs/token"
+)
+
+func Retrieve(reqContext *gin.Context) {
+	/*
+		タイムラインの投稿一覧を取得する関数。
+	*/
+	userId, err := token.ExtractUserIdFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to extract userId"})
+		reqContext.Error(err)
+		return
+	}
+	var interestTagIDs []int
+	err = models.DB.Model(&models.TUser{}).
+		Joins("JOIN t_user_interest_tags ON t_user_interest_tags.t_user_id = t_users.id").
+		Joins("JOIN t_interest_tags ON t_user_interest_tags.t_interest_tag_id =  t_interest_tags.id").
+		Where("t_users.id = ?", userId).
+		Pluck("t_interest_tags.id", &interestTagIDs).Error
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to retrieve interest tags"})
+		reqContext.Error(err)
+		return
+	}
+	reqContext.JSON(http.StatusOK, interestTagIDs)
+}

--- a/backend-go/srcs/post/retrieve.go
+++ b/backend-go/srcs/post/retrieve.go
@@ -30,12 +30,12 @@ func Retrieve(reqContext *gin.Context) {
 	}
 
 	var posts []models.TPost
-	err = models.DB.Preload("InterestTags").
+	err = models.DB.
+		Preload("InterestTags").
+		Preload("PostImageURL").
 		Where("is_draft = ?", false).
-		Joins("JOIN t_post_interest_tags pit ON t_posts.id = pit.t_post_id").
-		Where("pit.t_interest_tag_id IN (?)", interestTagIDs).
+		Where("id IN (?)", models.DB.Table("t_post_interest_tags").Select("t_post_id").Where("t_interest_tag_id IN (?)", interestTagIDs)).
 		Order("created_at DESC").
-		Distinct().
 		Find(&posts).Error
 
 	reqContext.JSON(http.StatusOK, gin.H{

--- a/backend-go/srcs/post/retrieve.go
+++ b/backend-go/srcs/post/retrieve.go
@@ -28,5 +28,17 @@ func Retrieve(reqContext *gin.Context) {
 		reqContext.Error(err)
 		return
 	}
-	reqContext.JSON(http.StatusOK, interestTagIDs)
+
+	var posts []models.TPost
+	err = models.DB.Preload("InterestTags").
+		Where("is_draft = ?", false).
+		Joins("JOIN t_post_interest_tags pit ON t_posts.id = pit.t_post_id").
+		Where("pit.t_interest_tag_id IN (?)", interestTagIDs).
+		Order("created_at DESC").
+		Distinct().
+		Find(&posts).Error
+
+	reqContext.JSON(http.StatusOK, gin.H{
+		"posts": posts,
+	})
 }

--- a/postman/user.json
+++ b/postman/user.json
@@ -184,6 +184,52 @@
         "description": "**説明**\n\n**投稿を提出するAPI**\n\n**JSONデータ**\n\n``` json\n{\n    \"Text\": \"文字列\",\n    \"InterestTags\": [\"tag1\", \"tag2\"...],\n    \"PostImageUrls\": [\"url1\", \"url2\"...],\n    \"Location\": \"座標\",\n    \"IsDraft\": \"trueかfalse\"\n}\n\n ```"
       },
       "response": []
+    },
+    {
+      "name": "投稿一覧取得",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"レスポンスが200であることを確認\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"レスポンスに'posts'フィールドが含まれていることを確認\", function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"posts\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": " Bearer {{jwt_token}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8080/posts/retrieve",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "posts",
+            "retrieve"
+          ]
+        }
+      },
+      "response": []
     }
   ]
 }


### PR DESCRIPTION
**説明**
投稿一覧取得のAPIを作成しました。
取得方法は以下の通りです。
1.ユーザーの趣味タグ一覧を参照
2.is_draft(下書きかどうか)がfalseのうち、投稿一覧からその投稿の趣味タグがユーザーの趣味タグと一致するもののみに絞り込む
3.投稿時間順に並び替える

**確認方法**
```
docker compose -f docker-compose.yml up --build -d
```
で起動したのち、postmanから「ユーザー登録」「ログイン」「投稿提出」「投稿一覧取得」を行なって、
「投稿一覧取得」の結果にpostsというフィールドが含まれていることを確認してください。
また、「投稿提出」をすこしデータの内容を変えたりして複数回POSTすると「投稿一覧取得」で投稿の配列が得られることを確認してください。
(※現在は投稿取得をするユーザーが設定している趣味タグのうち1つでもその投稿の趣味タグが一致していないと一覧で取得できないようにしています)

**今後の展望**
・10投稿ずつ取得できるように
・趣味タグが一致しなかった場合に一致しないものも取得できるように
・ユーザー分析をして投稿を選ぶ
・文字列検索機能