### PR TITLE
[Update] backendからデータベースを作成するように

### DIFF
--- a/backend-go/srcs/models/setup.go
+++ b/backend-go/srcs/models/setup.go
@@ -23,8 +23,6 @@ func ConnectDataBase() {
 	dbHost := os.Getenv("DATABASE_HOST")
 	dbPort := os.Getenv("DATABASE_PORT")
 
-	fmt.Printf("User: %s, Pass: %s, DB: %s, Host: %s, Port: %s\n", dbUser, dbPass, dbName, dbHost, dbPort)
-
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", dbUser, dbPass, dbHost, dbPort, dbName)
 	var err error
 	DB, err = gorm.Open(

--- a/backend-go/srcs/models/setup.go
+++ b/backend-go/srcs/models/setup.go
@@ -12,6 +12,20 @@ import (
 
 var DB *gorm.DB
 
+func createDataBase(dbUser string, dbPass string, dbHost string, dbPort string, dbName string) {
+	/*
+		データベース名を指定せずに接続したのち、データベースを作成する関数。
+		元々存在していたら実行されない。
+	*/
+	dsnWithoutDB := fmt.Sprintf("%s:%s@tcp(%s:%s)/?charset=utf8mb4&parseTime=True&loc=Local", dbUser, dbPass, dbHost, dbPort)
+	DB, err := gorm.Open(mysql.Open(dsnWithoutDB), &gorm.Config{})
+	if err != nil {
+		log.Fatal("Could not connect to database")
+	}
+
+	DB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName))
+}
+
 func ConnectDataBase() {
 	/*
 		環境変数からDSNを生成し、DATABASEとの接続を確立する関数。
@@ -23,6 +37,7 @@ func ConnectDataBase() {
 	dbHost := os.Getenv("DATABASE_HOST")
 	dbPort := os.Getenv("DATABASE_PORT")
 
+	createDataBase(dbUser, dbPass, dbHost, dbPort, dbName)
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", dbUser, dbPass, dbHost, dbPort, dbName)
 	var err error
 	DB, err = gorm.Open(

--- a/db-mysql/Dockerfile
+++ b/db-mysql/Dockerfile
@@ -1,6 +1,5 @@
 FROM mysql:9.2.0
 COPY ./configs/my.cnf /etc/my.cnf
-COPY ./init/create-default-table.sql /docker-entrypoint-initdb.d
 COPY ./entry-point.sh /
 RUN chmod +x /entry-point.sh
 

--- a/db-mysql/entry-point.sh
+++ b/db-mysql/entry-point.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';" >> /docker-entrypoint-initdb.d/create-default-table.sql
-echo "GRANT ALL PRIVILEGES ON matcha.* TO '${MYSQL_USER}'@'%';" >> /docker-entrypoint-initdb.d/create-default-table.sql
-echo "FLUSH PRIVILEGES;" >> /docker-entrypoint-initdb.d/create-default-table.sql
+echo "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';" > /docker-entrypoint-initdb.d/init.sql
+echo "GRANT ALL PRIVILEGES ON matcha.* TO '${MYSQL_USER}'@'%';" >> /docker-entrypoint-initdb.d/init.sql
+echo "FLUSH PRIVILEGES;" >> /docker-entrypoint-initdb.d/init.sql

--- a/db-mysql/init/create-default-table.sql
+++ b/db-mysql/init/create-default-table.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE IF NOT EXISTS matcha;
-USE matcha;


### PR DESCRIPTION
**説明**
デプロイ時はdbはコンテナではなくRDSを使用するので、
backendからデータベースを作成するようにしました。

**確認方法**
```
docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
```
で起動したのち、
db-mysqlコンテナで以下のコマンドを実行してDATABASE_NAMEの名前のデータベースが作成されていることを確認してください。
```
$ mysql -u root -p
> MYSQL_ROOT_PASSWORD
$ show databases;
```