### PR TITLE
[Feature] loginページで入力したデータをバックエンドに送るように

### DIFF
--- a/frontend-nodejs/app/(auth)/login/page.tsx
+++ b/frontend-nodejs/app/(auth)/login/page.tsx
@@ -72,11 +72,15 @@ const BookmarkError = ({ message }: { message: string }) => {
   );
 };
 
-const JapaneseLogin = () => {
+const Login = () => {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isComposing, setIsComposing] = useState(false);
+  // 送信中かどうかを示す状態
+  const [isLoading, setIsLoading] = useState(false);
+  // APIエラーを管理
+  const [apiError, setApiError] = useState("");
 
   // 入力エラー状態を管理
   const [errors, setErrors] = useState({
@@ -130,10 +134,50 @@ const JapaneseLogin = () => {
 
   const handleSubmit = async () => {
     setSubmitAttempted(true);
+    setApiError("");
 
     if (validateAllFields()) {
-      console.log("Registration submitted:", { username, email, password });
-      alert(`${username}として登録しました`);
+      try {
+        setIsLoading(true);
+
+        // ログインAPIリクエストを送信
+        const response = await fetch(`http://localhost:8080/auth/login`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            Username: username,
+            Email: email,
+            Password: password,
+          }),
+          credentials: "include",
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || "ログインに失敗しました");
+        }
+
+        const data = await response.json();
+        console.log("Registration successful:", data);
+        const token = data.token;
+
+        // トークンをローカルストレージに保存
+        localStorage.setItem("token", token);
+
+        // ログイン成功後のリダイレクト
+        window.location.href = "/";
+      } catch (error: unknown) {
+        console.log("Login error:", error);
+        let errorMessage = "ログインに失敗しました";
+        if (error instanceof Error) {
+          errorMessage = error.message;
+        }
+        setApiError(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
     } else {
       // エラーがある場合は、フォームへスクロール
       window.scrollTo({ top: 0, behavior: "smooth" });
@@ -198,6 +242,25 @@ const JapaneseLogin = () => {
             </h1>
           </button>
         </div>
+
+        {/* API エラーメッセージ */}
+        {apiError && (
+          <div className="mb-4 w-full max-w-md">
+            <div className="bg-red-100 border-l-4 border-red-500 p-4 rounded-md shadow-md">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <span className="text-2xl">⚠️</span>
+                </div>
+                <div className="ml-3">
+                  <p className="text-md font-medium text-red-900">
+                    エラーが発生しました
+                  </p>
+                  <p className="text-sm text-red-800 mt-1">{apiError}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* 共通エラーメッセージ */}
         {submitAttempted && Object.values(errors).includes(true) && (
@@ -302,14 +365,19 @@ const JapaneseLogin = () => {
           <div className="flex justify-center mt-4 mb-16">
             <button
               onClick={handleSubmit}
-              className="relative px-8 py-3 bg-rose-900 text-white font-bold rounded-lg transform hover:scale-105 transition-transform hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 shadow-lg"
+              disabled={isLoading}
+              className={`relative px-8 py-3 bg-rose-900 text-white font-bold rounded-lg transform transition-transform focus:outline-none focus:ring-2 focus:ring-amber-500 shadow-lg ${
+                isLoading
+                  ? "opacity-70 cursor-not-allowed"
+                  : "hover:scale-105 hover:bg-amber-700"
+              }`}
               style={{
                 textShadow: "0 2px 2px rgba(0,0,0,0.5)",
                 boxShadow:
                   "0 4px 6px rgba(0,0,0,0.3), inset 0 -2px 5px rgba(0,0,0,0.2), inset 0 2px 5px rgba(255,255,255,0.2)",
               }}
             >
-              入室する
+              {isLoading ? "送信中..." : "入室する"}
             </button>
           </div>
 
@@ -332,4 +400,4 @@ const JapaneseLogin = () => {
   );
 };
 
-export default JapaneseLogin;
+export default Login;

--- a/frontend-nodejs/app/(auth)/login/page.tsx
+++ b/frontend-nodejs/app/(auth)/login/page.tsx
@@ -141,12 +141,16 @@ const Login = () => {
         setIsLoading(true);
 
         // リクエストのボディを準備
-        const requestBody: {Username?: string, Email?: string, Password: string} = {
-          Password: password
+        const requestBody: {
+          Username?: string;
+          Email?: string;
+          Password: string;
+        } = {
+          Password: password,
         };
 
         // ユーザー名かメールアドレスを判別して設定
-        if (usernameOrEmail.includes('@')) {
+        if (usernameOrEmail.includes("@")) {
           requestBody.Email = usernameOrEmail;
         } else {
           requestBody.Username = usernameOrEmail;
@@ -162,20 +166,36 @@ const Login = () => {
           credentials: "include",
         });
 
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.message || "ログインに失敗しました");
+        let data;
+        try {
+          // レスポンスのテキストを取得してJSONとしてパース
+          const responseText = await response.text();
+
+          // JSONとしてパース
+          data = JSON.parse(responseText);
+
+          // エラーレスポンスの場合
+          if (!response.ok) {
+            console.error("詳細エラー情報:", data);
+            throw new Error("ログインに失敗しました");
+          }
+
+          // 成功レスポンスの処理
+          console.log("Login successful:", data);
+          const token = data.token;
+
+          // トークンをローカルストレージに保存
+          localStorage.setItem("token", token);
+
+          // ログイン成功後のリダイレクト
+          window.location.href = "/";
+        } catch (error) {
+          // JSONパースエラーまたはその他のエラー
+          console.error("Login error:", error);
+          throw new Error("ログインに失敗しました");
+        } finally {
+          setIsLoading(false);
         }
-
-        const data = await response.json();
-        console.log("Login successful:", data);
-        const token = data.token;
-
-        // トークンをローカルストレージに保存
-        localStorage.setItem("token", token);
-
-        // ログイン成功後のリダイレクト
-        window.location.href = "/";
       } catch (error: unknown) {
         console.log("Login error:", error);
         let errorMessage = "ログインに失敗しました";
@@ -183,8 +203,6 @@ const Login = () => {
           errorMessage = error.message;
         }
         setApiError(errorMessage);
-      } finally {
-        setIsLoading(false);
       }
     } else {
       // エラーがある場合は、フォームへスクロール
@@ -200,8 +218,11 @@ const Login = () => {
   };
 
   // 入力枠のスタイル
-  const getInputStyle = (fieldName: "usernameOrEmail" | "password", value: string) => {
-    return (errors[fieldName] && (!value || value.trim() === ""))
+  const getInputStyle = (
+    fieldName: "usernameOrEmail" | "password",
+    value: string,
+  ) => {
+    return errors[fieldName] && (!value || value.trim() === "")
       ? "w-full px-4 py-3 bg-white bg-opacity-70 rounded-lg border-2 border-red-500 shadow-md focus:outline-none focus:ring-2 focus:ring-red-500 animate-pulse"
       : "w-full px-4 py-3 bg-white bg-opacity-70 rounded-lg border-2 border-amber-800 shadow-md focus:outline-none focus:ring-2 focus:ring-amber-500";
   };

--- a/frontend-nodejs/app/(auth)/login/page.tsx
+++ b/frontend-nodejs/app/(auth)/login/page.tsx
@@ -171,8 +171,17 @@ const Login = () => {
           // レスポンスのテキストを取得してJSONとしてパース
           const responseText = await response.text();
 
-          // JSONとしてパース
-          data = JSON.parse(responseText);
+          // 空のレスポンスチェック
+          if (!responseText.trim()) {
+            console.error("空のレスポンスを受信しました");
+            if (!response.ok) {
+              throw new Error("ログインに失敗しました");
+            }
+            data = {}; // 空のオブジェクトをデフォルト値として使用
+          } else {
+            // JSONとしてパース
+            data = JSON.parse(responseText);
+          }
 
           // エラーレスポンスの場合
           if (!response.ok) {

--- a/frontend-nodejs/app/(auth)/login/page.tsx
+++ b/frontend-nodejs/app/(auth)/login/page.tsx
@@ -8,6 +8,7 @@ const WoodenSign = ({
   children,
   width = "w-64",
   height = "h-12",
+  rotation = "",
 }: {
   children: ReactNode;
   width?: string;
@@ -48,7 +49,7 @@ const WoodenSign = ({
       />
 
       <div
-        className={`relative ${width} ${height} bg-orange-300 flex items-center justify-center px-4 transform border-2 border-yellow-900 rounded z-10`}
+        className={`relative ${width} ${height} bg-orange-300 flex items-center justify-center px-4 transform ${rotation} border-2 border-yellow-900 rounded z-10`}
       >
         <Nail position="topLeft" />
         <Nail position="topRight" />
@@ -72,9 +73,17 @@ const BookmarkError = ({ message }: { message: string }) => {
   );
 };
 
+// 必須タグコンポーネント
+const RequiredTag = () => {
+  return (
+    <span className="ml-2 px-2 py-0.5 bg-amber-600 text-white text-xs font-bold rounded-full animate-pulse">
+      必須
+    </span>
+  );
+};
+
 const Login = () => {
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
+  const [usernameOrEmail, setUsernameOrEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isComposing, setIsComposing] = useState(false);
   // 送信中かどうかを示す状態
@@ -84,24 +93,16 @@ const Login = () => {
 
   // 入力エラー状態を管理
   const [errors, setErrors] = useState({
-    username: false,
-    email: false,
+    usernameOrEmail: false,
     password: false,
   });
   // 送信が試行されたかどうか
   const [submitAttempted, setSubmitAttempted] = useState(false);
 
-  const handleUsername = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setUsername(e.target.value);
+  const handleUsernameOrEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUsernameOrEmail(e.target.value);
     if (submitAttempted) {
-      validateField("username", e.target.value);
-    }
-  };
-
-  const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
-    if (submitAttempted) {
-      validateField("email", e.target.value);
+      validateField("usernameOrEmail", e.target.value);
     }
   };
 
@@ -123,8 +124,7 @@ const Login = () => {
   // 全フィールドの検証
   const validateAllFields = () => {
     const newErrors = {
-      username: username.trim() === "",
-      email: email.trim() === "",
+      usernameOrEmail: usernameOrEmail.trim() === "",
       password: password.trim() === "",
     };
 
@@ -140,17 +140,25 @@ const Login = () => {
       try {
         setIsLoading(true);
 
+        // リクエストのボディを準備
+        const requestBody: {Username?: string, Email?: string, Password: string} = {
+          Password: password
+        };
+
+        // ユーザー名かメールアドレスを判別して設定
+        if (usernameOrEmail.includes('@')) {
+          requestBody.Email = usernameOrEmail;
+        } else {
+          requestBody.Username = usernameOrEmail;
+        }
+
         // ログインAPIリクエストを送信
         const response = await fetch(`http://localhost:8080/auth/login`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            Username: username,
-            Email: email,
-            Password: password,
-          }),
+          body: JSON.stringify(requestBody),
           credentials: "include",
         });
 
@@ -160,7 +168,7 @@ const Login = () => {
         }
 
         const data = await response.json();
-        console.log("Registration successful:", data);
+        console.log("Login successful:", data);
         const token = data.token;
 
         // トークンをローカルストレージに保存
@@ -192,8 +200,8 @@ const Login = () => {
   };
 
   // 入力枠のスタイル
-  const getInputStyle = (fieldName: "username" | "email" | "password") => {
-    return errors[fieldName]
+  const getInputStyle = (fieldName: "usernameOrEmail" | "password", value: string) => {
+    return (errors[fieldName] && (!value || value.trim() === ""))
       ? "w-full px-4 py-3 bg-white bg-opacity-70 rounded-lg border-2 border-red-500 shadow-md focus:outline-none focus:ring-2 focus:ring-red-500 animate-pulse"
       : "w-full px-4 py-3 bg-white bg-opacity-70 rounded-lg border-2 border-amber-800 shadow-md focus:outline-none focus:ring-2 focus:ring-amber-500";
   };
@@ -243,6 +251,25 @@ const Login = () => {
           </button>
         </div>
 
+        {/* 入力フォームの説明 */}
+        <div className="mb-6 w-full max-w-md">
+          <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded-md shadow-md">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <span className="text-2xl">📝</span>
+              </div>
+              <div className="ml-3">
+                <p className="text-md font-medium text-amber-900">
+                  入室に必要な情報
+                </p>
+                <p className="text-sm text-amber-800 mt-1">
+                  ユーザー名かメールアドレスのどちらか一方と、パスワードを入力してください。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
         {/* API エラーメッセージ */}
         {apiError && (
           <div className="mb-4 w-full max-w-md">
@@ -275,7 +302,7 @@ const Login = () => {
                     まだ終わってないよ！
                   </p>
                   <p className="text-sm text-amber-800 mt-1">
-                    赤くなっている部分を入力してね。入力すると色が変わるよ！
+                    赤くなっている必須項目を入力してね。入力すると色が変わるよ！
                   </p>
                 </div>
               </div>
@@ -284,55 +311,33 @@ const Login = () => {
         )}
 
         <div className="w-full max-w-md">
-          {/* ユーザー名フィールド */}
-          <div className="mb-8">
-            <div className="relative">
-              <WoodenSign width="w-full">
-                <label className="text-yellow-950 text-lg font-bold drop-shadow-[0_1px_1px_rgba(255,255,255,0.5)]">
-                  ユーザー名
-                </label>
-              </WoodenSign>
-            </div>
-
-            <div className="relative mt-2 flex items-center">
-              <input
-                type="text"
-                value={username}
-                onChange={handleUsername}
-                onKeyDown={handleKeyDown}
-                onCompositionStart={() => setIsComposing(true)}
-                onCompositionEnd={() => setIsComposing(false)}
-                className={getInputStyle("username")}
-                placeholder="例）taro"
-              />
-            </div>
-            {errors.username && submitAttempted && (
-              <BookmarkError message="ユーザー名を入力してね！" />
-            )}
-          </div>
-
-          {/* メールアドレスフィールド */}
+          {/* ユーザー名/メールアドレスフィールド */}
           <div className="mb-8">
             <div className="relative">
               <WoodenSign width="w-full" rotation="-rotate-1">
-                <label className="text-yellow-950 text-lg font-bold drop-shadow-[0_1px_1px_rgba(255,255,255,0.5)]">
-                  メールアドレス
-                </label>
+                <div className="flex items-center">
+                  <label className="text-yellow-950 text-lg font-bold drop-shadow-[0_1px_1px_rgba(255,255,255,0.5)]">
+                    ユーザー名 または メールアドレス
+                  </label>
+                  <RequiredTag />
+                </div>
               </WoodenSign>
             </div>
 
             <div className="relative mt-2">
               <input
-                type="email"
-                value={email}
-                onChange={handleEmail}
+                type="text"
+                value={usernameOrEmail}
+                onChange={handleUsernameOrEmail}
                 onKeyDown={handleKeyDown}
-                className={getInputStyle("email")}
-                placeholder="例）taro@example.com"
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+                className={getInputStyle("usernameOrEmail", usernameOrEmail)}
+                placeholder="例）taro または taro@example.com"
               />
             </div>
-            {errors.email && submitAttempted && (
-              <BookmarkError message="メールアドレスを入力してね！" />
+            {errors.usernameOrEmail && submitAttempted && (
+              <BookmarkError message="ユーザー名またはメールアドレスを入力してね！" />
             )}
           </div>
 
@@ -340,9 +345,12 @@ const Login = () => {
           <div className="mb-8">
             <div className="relative">
               <WoodenSign width="w-full" rotation="rotate-1">
-                <label className="text-yellow-950 text-lg font-bold drop-shadow-[0_1px_1px_rgba(255,255,255,0.5)]">
-                  パスワード
-                </label>
+                <div className="flex items-center">
+                  <label className="text-yellow-950 text-lg font-bold drop-shadow-[0_1px_1px_rgba(255,255,255,0.5)]">
+                    パスワード
+                  </label>
+                  <RequiredTag />
+                </div>
               </WoodenSign>
             </div>
 
@@ -352,7 +360,7 @@ const Login = () => {
                 value={password}
                 onChange={handlePassword}
                 onKeyDown={handleKeyDown}
-                className={getInputStyle("password")}
+                className={getInputStyle("password", password)}
                 placeholder="例）taro1234"
               />
             </div>


### PR DESCRIPTION
＜やったこと＞
- UI一部修正（メールアドレス or ユーザー名のどちらかを選択する旨を伝えるように）
- 新規登録後、ログインページでログインできるようにしました。

＜確認方法＞
1. `docker compose up --build -d`
2. `http://localhost:3000`にアクセス
3. 新規登録をしてください
4. その後、ログインページに遷移するので、ログインしてください（誤った情報を入れたりもしてみてください）
5. 現在はまだホストページの作成ができていないので成功すると再び`http://localhost:3000`に戻る挙動になっています。

＜共有事項＞
1. 新規登録画面のメールアドレス設定で現在は@がなくても登録できるようになっています。そのような細かい修正に関しては全体機能を作り終えた後に追加していく予定です。

＜次やること＞
- ホストページ作成
- ログインしたらホストページに飛ぶように