### PR TITLE
[Feature] host pageの作成

### DIFF
--- a/frontend-nodejs/app/(auth)/login/page.tsx
+++ b/frontend-nodejs/app/(auth)/login/page.tsx
@@ -197,7 +197,7 @@ const Login = () => {
           localStorage.setItem("token", token);
 
           // ログイン成功後のリダイレクト
-          window.location.href = "/";
+          window.location.href = "/host/theme-selection";
         } catch (error) {
           // JSONパースエラーまたはその他のエラー
           console.error("Login error:", error);

--- a/frontend-nodejs/app/host/theme-selection/loading.tsx
+++ b/frontend-nodejs/app/host/theme-selection/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null;
+}

--- a/frontend-nodejs/app/host/theme-selection/page.tsx
+++ b/frontend-nodejs/app/host/theme-selection/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { Check, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// テーマの種類
+type ThemeType =
+  | "spring"
+  | "summer"
+  | "autumn"
+  | "winter"
+  | "minimal"
+  | "focus"
+  | "nature"
+  | "cafe";
+
+// テーマデータ
+const themes = [
+  {
+    id: "spring",
+    name: "春",
+    description: "桜と新緑の爽やかな雰囲気",
+    color: "bg-pink-100",
+    borderColor: "border-pink-400",
+    textColor: "text-pink-800",
+    buttonColor: "bg-pink-500 hover:bg-pink-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "summer",
+    name: "夏",
+    description: "南国リゾートの開放感",
+    color: "bg-green-100",
+    borderColor: "border-green-400",
+    textColor: "text-green-800",
+    buttonColor: "bg-green-500 hover:bg-green-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "autumn",
+    name: "秋",
+    description: "紅葉と実りの季節",
+    color: "bg-orange-100",
+    borderColor: "border-orange-400",
+    textColor: "text-orange-800",
+    buttonColor: "bg-orange-500 hover:bg-orange-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "winter",
+    name: "冬",
+    description: "雪景色の静かな空間",
+    color: "bg-blue-100",
+    borderColor: "border-blue-400",
+    textColor: "text-blue-800",
+    buttonColor: "bg-blue-500 hover:bg-blue-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "minimal",
+    name: "ミニマル",
+    description: "シンプルで集中できる空間",
+    color: "bg-slate-100",
+    borderColor: "border-slate-400",
+    textColor: "text-slate-800",
+    buttonColor: "bg-slate-500 hover:bg-slate-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "focus",
+    name: "フォーカス",
+    description: "ダークモードで目に優しい",
+    color: "bg-gray-800",
+    borderColor: "border-gray-600",
+    textColor: "text-gray-100",
+    buttonColor: "bg-indigo-500 hover:bg-indigo-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "nature",
+    name: "自然",
+    description: "森林浴のリラックス効果",
+    color: "bg-emerald-100",
+    borderColor: "border-emerald-400",
+    textColor: "text-emerald-800",
+    buttonColor: "bg-emerald-500 hover:bg-emerald-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+  {
+    id: "cafe",
+    name: "カフェ",
+    description: "カフェのくつろぎ空間",
+    color: "bg-amber-100",
+    borderColor: "border-amber-400",
+    textColor: "text-amber-800",
+    buttonColor: "bg-amber-500 hover:bg-amber-600",
+    image: "/placeholder.svg?height=400&width=400",
+  },
+];
+
+export default function ThemeSelectionPage() {
+  const router = useRouter();
+  const [selectedTheme, setSelectedTheme] = useState<ThemeType | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  // 1ページあたりのテーマ数
+  const themesPerPage = 4;
+
+  // ページ数を計算
+  const totalPages = Math.ceil(themes.length / themesPerPage);
+
+  // 現在のページのテーマを取得
+  const currentThemes = themes.slice(
+    currentPage * themesPerPage,
+    (currentPage + 1) * themesPerPage,
+  );
+
+  // 次のページへ
+  const nextPage = () => {
+    if (currentPage < totalPages - 1) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  // 前のページへ
+  const prevPage = () => {
+    if (currentPage > 0) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  // テーマを選択
+  const selectTheme = (themeId: ThemeType) => {
+    setSelectedTheme(themeId);
+  };
+
+  // テーマを確定
+  const confirmTheme = async () => {
+    if (!selectedTheme) return;
+
+    setIsConfirming(true);
+
+    try {
+      // 実際の実装ではAPIリクエストを行う
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // 成功したらダッシュボードへリダイレクト
+      router.push("/host/dashboard");
+    } catch (error) {
+      console.error("テーマの設定に失敗しました", error);
+      setIsConfirming(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-blue-50 dark:from-slate-900 dark:to-blue-900">
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-12">
+            <h1 className="text-3xl md:text-4xl font-bold text-slate-800 dark:text-white mb-4">
+              自習室のデザインを選んでください
+            </h1>
+            <p className="text-slate-600 dark:text-slate-300 max-w-2xl mx-auto">
+              あなたの自習室の雰囲気を決めるテーマを選択してください。
+              参加者が集中しやすい環境づくりに役立ちます。
+            </p>
+          </div>
+
+          <div className="relative">
+            {/* ページネーションボタン（前へ） */}
+            {currentPage > 0 && (
+              <button
+                onClick={prevPage}
+                className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 z-10 bg-white dark:bg-slate-800 rounded-full p-2 shadow-md text-slate-600 dark:text-slate-200 hover:text-slate-900 dark:hover:text-white"
+                aria-label="前のページ"
+              >
+                <ChevronLeft className="h-6 w-6" />
+              </button>
+            )}
+
+            {/* テーマグリッド */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              {currentThemes.map((theme) => (
+                <motion.div
+                  key={theme.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3 }}
+                  className={cn(
+                    "relative rounded-2xl overflow-hidden border-2 transition-all duration-300",
+                    theme.color,
+                    theme.borderColor,
+                    selectedTheme === theme.id
+                      ? "ring-4 ring-blue-400 dark:ring-blue-500 scale-105 shadow-lg"
+                      : "hover:scale-102 shadow-md",
+                  )}
+                  onClick={() => selectTheme(theme.id as ThemeType)}
+                >
+                  <div className="aspect-square relative">
+                    <Image
+                      src={theme.image || "/placeholder.svg"}
+                      alt={`${theme.name}テーマ`}
+                      fill
+                      className="object-cover p-4"
+                    />
+
+                    {/* 選択チェックマーク */}
+                    {selectedTheme === theme.id && (
+                      <div className="absolute top-3 right-3 bg-blue-500 text-white rounded-full p-1">
+                        <Check className="h-5 w-5" />
+                      </div>
+                    )}
+
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <h2 className={cn("text-6xl font-bold", theme.textColor)}>
+                        {theme.name}
+                      </h2>
+                    </div>
+                  </div>
+
+                  <div className="p-4">
+                    <p className={cn("text-sm", theme.textColor)}>
+                      {theme.description}
+                    </p>
+
+                    <button
+                      className={cn(
+                        "mt-3 w-full py-2 px-4 rounded-full text-white font-medium transition-all duration-300 flex items-center justify-center",
+                        theme.buttonColor,
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        selectTheme(theme.id as ThemeType);
+                        confirmTheme();
+                      }}
+                    >
+                      {isConfirming && selectedTheme === theme.id ? (
+                        <div className="flex items-center">
+                          <svg
+                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            ></circle>
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            ></path>
+                          </svg>
+                          設定中...
+                        </div>
+                      ) : (
+                        "確定する"
+                      )}
+                    </button>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            {/* ページネーションボタン（次へ） */}
+            {currentPage < totalPages - 1 && (
+              <button
+                onClick={nextPage}
+                className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 z-10 bg-white dark:bg-slate-800 rounded-full p-2 shadow-md text-slate-600 dark:text-slate-200 hover:text-slate-900 dark:hover:text-white"
+                aria-label="次のページ"
+              >
+                <ChevronRight className="h-6 w-6" />
+              </button>
+            )}
+          </div>
+
+          {/* ページネーションインジケーター */}
+          <div className="flex justify-center mt-8 space-x-2">
+            {Array.from({ length: totalPages }).map((_, index) => (
+              <button
+                key={index}
+                className={cn(
+                  "w-2.5 h-2.5 rounded-full transition-all duration-300",
+                  currentPage === index
+                    ? "bg-blue-500 w-6"
+                    : "bg-slate-300 dark:bg-slate-600 hover:bg-slate-400 dark:hover:bg-slate-500",
+                )}
+                onClick={() => setCurrentPage(index)}
+                aria-label={`ページ ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          {/* カスタムテーマボタン */}
+          <div className="mt-12 text-center">
+            <button className="inline-flex items-center px-6 py-3 rounded-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-medium shadow-md hover:shadow-lg transition-all duration-300">
+              <Sparkles className="h-5 w-5 mr-2" />
+              カスタムテーマを作成
+            </button>
+
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+              オリジナルのテーマを作成して、自分だけの自習室を演出できます
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-nodejs/app/host/theme-selection/page.tsx
+++ b/frontend-nodejs/app/host/theme-selection/page.tsx
@@ -107,6 +107,7 @@ export default function ThemeSelectionPage() {
   const [selectedTheme, setSelectedTheme] = useState<ThemeType | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const [isConfirming, setIsConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // 1ページあたりのテーマ数
   const themesPerPage = 4;
@@ -144,16 +145,89 @@ export default function ThemeSelectionPage() {
     if (!selectedTheme) return;
 
     setIsConfirming(true);
+    setError(null); // エラーをリセット
 
     try {
-      // 実際の実装ではAPIリクエストを行う
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // テーマ情報を取得
+      const theme = themes.find((theme) => theme.id === selectedTheme);
 
-      // 成功したらダッシュボードへリダイレクト
-      router.push("/host/dashboard");
+      if (!theme) {
+        throw new Error("選択されたテーマが見つかりませんでした");
+      }
+
+      // リクエストボディをログに出力
+      const requestBody = {
+        StudyRoomName: `${theme.name}の自習室`,
+        StudyRoomImageURL: theme.image || "/placeholder.svg",
+      };
+      console.log("Request body:", JSON.stringify(requestBody));
+
+      // トークンの確認
+      const token = localStorage.getItem("token");
+      if (!token) {
+        console.warn(
+          "認証トークンがありません。ログインが必要かもしれません。",
+        );
+      }
+
+      // バックエンドAPIにリクエストを送信してルームコードを取得
+      const response = await fetch("http://localhost:8080/study-room/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(requestBody),
+        credentials: "include",
+      });
+
+      // レスポンスのステータスと生のテキストを出力してデバッグ
+      console.log("Response status:", response.status);
+      const responseText = await response.text();
+      console.log("Raw response text:", responseText);
+
+      if (!response.ok) {
+        // JSON解析を試みる前に、エラーかどうかを確認
+        try {
+          const errorData = JSON.parse(responseText);
+          throw new Error(errorData.error || "自習室の作成に失敗しました");
+        } catch (parseError) {
+          console.error("JSONパースエラー:", parseError);
+          throw new Error("サーバーからの応答の解析に失敗しました");
+        }
+      }
+
+      // JSONの解析を安全に行う
+      let data;
+      try {
+        data = JSON.parse(responseText);
+        console.log("ルーム作成成功:", data);
+      } catch (parseError) {
+        console.error("JSONパースエラー:", parseError);
+        throw new Error("サーバーからの応答の解析に失敗しました");
+      }
+
+      // ルームコードをlocalStorageに保存しておく（オプション）
+      if (data.roomCode) {
+        localStorage.setItem("currentRoomCode", data.roomCode);
+      }
+
+      // 成功したらダッシュボードへリダイレクト（ルームコードをクエリパラメータで渡す）
+      router.push(`/host/dashboard?roomCode=${data.roomCode || ""}`);
     } catch (error) {
       console.error("テーマの設定に失敗しました", error);
       setIsConfirming(false);
+
+      // エラー情報をより詳細に表示
+      if (error instanceof Error) {
+        setError(`自習室の作成に失敗しました: ${error.message}`);
+      } else if (typeof error === "string") {
+        setError(`自習室の作成に失敗しました: ${error}`);
+      } else {
+        setError(
+          "予期せぬエラーが発生しました。ネットワーク接続とログイン状態を確認してください。",
+        );
+      }
     }
   };
 
@@ -161,6 +235,17 @@ export default function ThemeSelectionPage() {
     <div className="min-h-screen bg-gradient-to-br from-teal-50 to-blue-50 dark:from-slate-900 dark:to-blue-900">
       <div className="container mx-auto px-4 py-12">
         <div className="max-w-6xl mx-auto">
+          {/* エラーメッセージの表示 */}
+          {error && (
+            <div
+              className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6 rounded-md"
+              role="alert"
+            >
+              <p className="font-bold">エラー</p>
+              <p>{error}</p>
+            </div>
+          )}
+
           <div className="text-center mb-12">
             <h1 className="text-3xl md:text-4xl font-bold text-slate-800 dark:text-white mb-4">
               自習室のデザインを選んでください
@@ -303,7 +388,10 @@ export default function ThemeSelectionPage() {
 
           {/* カスタムテーマボタン */}
           <div className="mt-12 text-center">
-            <button className="inline-flex items-center px-6 py-3 rounded-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-medium shadow-md hover:shadow-lg transition-all duration-300">
+            <button
+              className="inline-flex items-center px-6 py-3 rounded-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-medium shadow-md hover:shadow-lg transition-all duration-300"
+              onClick={() => router.push("/host/theme-selection/customize")}
+            >
               <Sparkles className="h-5 w-5 mr-2" />
               カスタムテーマを作成
             </button>

--- a/frontend-nodejs/components/ui/avatar.tsx
+++ b/frontend-nodejs/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className,
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/frontend-nodejs/components/ui/badge.tsx
+++ b/frontend-nodejs/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/frontend-nodejs/components/ui/card.tsx
+++ b/frontend-nodejs/components/ui/card.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/frontend-nodejs/components/ui/label.tsx
+++ b/frontend-nodejs/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/frontend-nodejs/components/ui/slider.tsx
+++ b/frontend-nodejs/components/ui/slider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "@/lib/utils";
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className,
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/frontend-nodejs/components/ui/switch.tsx
+++ b/frontend-nodejs/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/frontend-nodejs/components/ui/tabs.tsx
+++ b/frontend-nodejs/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend-nodejs/package-lock.json
+++ b/frontend-nodejs/package-lock.json
@@ -8,11 +8,17 @@
       "name": "frontend-nodejs",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-slider": "^1.2.3",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-switch": "^1.1.3",
+        "@radix-ui/react-tabs": "^1.1.3",
         "class-variance-authority": "^0.7.1",
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.5.0",
         "lucide-react": "^0.475.0",
         "next": "^15.1.6",
         "react": "^19.0.0",
@@ -1302,11 +1308,69 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
       "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
+      "integrity": "sha512-Paen00T4P8L8gd9bNsRMw7Cbaz85oxiv+hzomsRZgFm2byltPFDtfcoqlWJ8GyZlIBWgLssJlzLCnKU0G0302g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.1",
@@ -1370,6 +1434,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1459,6 +1538,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.2.tgz",
+      "integrity": "sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
@@ -1530,6 +1632,70 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.2.tgz",
+      "integrity": "sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.2.3.tgz",
+      "integrity": "sha512-nNrLAWLjGESnhqBqcCNW4w2nn7LxudyMzeB6VgdyAnFLC6kfQgnAjSL2v6UkQTnDctJBlxrmxfplWS4iYjdUTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
@@ -1544,6 +1710,65 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
+      "integrity": "sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.3.tgz",
+      "integrity": "sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-roving-focus": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1604,6 +1829,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3963,6 +4221,33 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.5.0.tgz",
+      "integrity": "sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.5.0",
+        "motion-utils": "^12.5.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -5288,6 +5573,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.5.0.tgz",
+      "integrity": "sha512-uH2PETDh7m+Hjd1UQQ56yHqwn83SAwNjimNPE/kC+Kds0t4Yh7+29rfo5wezVFpPOv57U4IuWved5d1x0kNhbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.5.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.5.0.tgz",
+      "integrity": "sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/frontend-nodejs/package.json
+++ b/frontend-nodejs/package.json
@@ -10,11 +10,17 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-slider": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-switch": "^1.1.3",
+    "@radix-ui/react-tabs": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.5.0",
     "lucide-react": "^0.475.0",
     "next": "^15.1.6",
     "react": "^19.0.0",


### PR DESCRIPTION
＜やったこと＞
- ホストページ（部屋のデザイン選択画面）を作成しました
- ルームを選択した際に、バックエンドAPIにリクエストを送信してルームコードを取得できるようにしました

＜確認方法＞
1. `docker compose up --build -d`
2. `http://localhost:3000`
3. 新規登録 -> ログインした後、デザイン選択画面が表示されることを確認してください
4. 好きなデザインを選択すると、開発ツールに以下のようなルームコードが送られてきていることを確認してください（今は遷移先のページがないので404が出ています。**`roomCode=`** の後の６桁の数値がバックエンド側で生成されたルームコードです。）
<img width="402" alt="スクリーンショット 2025-03-16 16 32 37" src="https://github.com/user-attachments/assets/57647cb0-2410-4fcc-bd8f-3b18706e690c" />

＜共有事項＞
- Files changedに12個のファイルの変更がありますが、`frontend-nodejs/components/ui/`　で始まるファイルは自動生成されたファイルなので特に見なくても良いかもしれません👀（自分も見てません）
- 主に書いたファイルは**frontend-nodejs/app/host/theme-selection/page.tsx**です。

＜次やること＞
- ゲストページの作成
- ゲスト or ホストを選択するボタンを追加