### PR TITLE
[Feature] プロフィール設定APIを作成しました

### DIFF
--- a/backend-go/srcs/auth/login.go
+++ b/backend-go/srcs/auth/login.go
@@ -36,24 +36,24 @@ func Login(reqContext *gin.Context) {
 	var loginInput LoginInput
 
 	if err := reqContext.ShouldBindJSON(&loginInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 	if err := loginInput.validate(); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid input"})
 		reqContext.Error(err)
 		return
 	}
 
 	jwtTokenString, err := models.FetchUserAndGenerateJWTTokenString(loginInput.Username, loginInput.Email, loginInput.Password)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to generate JWT"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to generate JWT"})
 		reqContext.Error(err)
 		return
 	}
 
 	reqContext.JSON(http.StatusOK, gin.H{
-		"token": jwtTokenString,
+		"Token": jwtTokenString,
 	})
 }

--- a/backend-go/srcs/auth/otp.go
+++ b/backend-go/srcs/auth/otp.go
@@ -77,7 +77,7 @@ type GenerateOTPInput struct {
 	/*
 		OTP生成時にリクエストから抽出するJSONデータの構造体
 	*/
-	Email string `json:"email" binding:"required"`
+	Email string `json:"Email" binding:"required"`
 }
 
 func GenerateOTPHandler(reqContext *gin.Context) {
@@ -88,35 +88,35 @@ func GenerateOTPHandler(reqContext *gin.Context) {
 	var generateOTPInput GenerateOTPInput
 	err := reqContext.ShouldBindJSON(&generateOTPInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	OTP, err := utils.GenerateRandomCode(6)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to generate OTP"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = mail.SendMail(generateOTPInput.Email, mail_contents.CreateOTPSubject(), mail_contents.CreateOTPMailText(OTP), mail_contents.CreateOTPMailHTML(OTP))
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to generate OTP"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = saveOTP(generateOTPInput.Email, OTP)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to save OTP"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = cleanupExpiredOTPs()
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cleanup expired OTPs"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to cleanup expired OTPs"})
 		reqContext.Error(err)
 		return
 	}
@@ -165,8 +165,8 @@ type VerifyOTPInput struct {
 	/*
 		OTP認証時にリクエストから抽出するJSONデータの構造体
 	*/
-	Email string `json:"email" binding:"required"`
-	OTP   string `json:"otp" binding:"required"`
+	Email string `json:"Email" binding:"required"`
+	OTP   string `json:"OTP" binding:"required"`
 }
 
 func VerifyOTPHandler(reqContext *gin.Context) {
@@ -176,14 +176,14 @@ func VerifyOTPHandler(reqContext *gin.Context) {
 	var verifyOTPInput VerifyOTPInput
 	err := reqContext.ShouldBindJSON(&verifyOTPInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = verifyOTP(verifyOTPInput.Email, verifyOTPInput.OTP)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to verify OTP"})
 		reqContext.Error(err)
 		return
 	}

--- a/backend-go/srcs/auth/register.go
+++ b/backend-go/srcs/auth/register.go
@@ -46,26 +46,26 @@ func Register(reqContext *gin.Context) {
 	var registerInput RegisterInput
 
 	if err := reqContext.ShouldBindJSON(&registerInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	isVerified, err := IsEmailVerified(registerInput.Email)
 	if !isVerified && err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Email is not verified"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Email is not verified"})
 		reqContext.Error(err)
 		return
 	}
 
 	user, err := registerUser(registerInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to create user"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to create user"})
 		reqContext.Error(err)
 		return
 	}
 
 	reqContext.JSON(http.StatusOK, gin.H{
-		"user": user.PrepareOutput(),
+		"User": user.PrepareOutput(),
 	})
 }

--- a/backend-go/srcs/mail_contents/password_forgot.go
+++ b/backend-go/srcs/mail_contents/password_forgot.go
@@ -1,0 +1,29 @@
+package mail_contents
+
+import "fmt"
+
+func CreatePasswordForgotSubject() string {
+	return "[Matcha]パスワード変更の案内"
+}
+
+func CreatePasswordForgotMailHTML(OTP string) string {
+	return fmt.Sprintf(`
+		<h3>--- 以下のワンタイムパスワードを使用することでパスワードを再設定できます！ ---</h3>
+		<p>下記のワンタイムパスワードをアプリに入力してください。（有効期限5分）</p>
+		<p><strong style="font-size: 24px;">%s</strong></p>
+		<br>
+		<p>このメールに心当たりがなければ無視してください。</p>
+	`, OTP)
+}
+
+func CreatePasswordForgotMailText(OTP string) string {
+	return fmt.Sprintf(`
+		--- 以下のワンタイムパスワードを使用することでパスワードを再設定できます！ ---
+
+		下記のワンタイムパスワードをアプリに入力してください。（有効期限5分）
+
+		%s
+
+		このメールに心当たりがなければ無視してください。
+	`, OTP)
+}

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -6,6 +6,7 @@ import (
 	"srcs/auth"
 	"srcs/middlewares"
 	"srcs/models"
+	"srcs/password"
 	"srcs/profile"
 	"srcs/reports"
 	"srcs/study_room"
@@ -67,6 +68,10 @@ func main() {
 	profileRoutes.Use(middlewares.JWTValidationMiddleware())
 	profileRoutes.GET("/get", profile.GetProfileHandler)
 	profileRoutes.PUT("/update", profile.UpdateProfileHandler)
+
+	passwordRoutes := router.Group("password")
+	passwordRoutes.POST("/forgot", password.ForgotPasswordHandler)
+	passwordRoutes.PUT("/reset", password.ResetPasswordHandler)
 
 	studyRoomRoutes := router.Group("/study-room")
 	studyRoomRoutes.Use(middlewares.JWTValidationMiddleware())

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	router.GET("/health", func(reqContext *gin.Context) {
 		reqContext.JSON(http.StatusOK, gin.H{
-			"status": "OK",
+			"Status": "OK",
 		})
 	})
 

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -6,6 +6,7 @@ import (
 	"srcs/auth"
 	"srcs/middlewares"
 	"srcs/models"
+	"srcs/profile"
 	"srcs/reports"
 	"srcs/study_room"
 	"srcs/utils"
@@ -61,6 +62,11 @@ func main() {
 	authRoutes.POST("/otp/verify", auth.VerifyOTPHandler)
 	authRoutes.POST("/register", auth.Register)
 	authRoutes.POST("/login", auth.Login)
+
+	profileRoutes := router.Group("/profile")
+	profileRoutes.Use(middlewares.JWTValidationMiddleware())
+	profileRoutes.GET("/get", profile.GetProfileHandler)
+	profileRoutes.PUT("/update", profile.UpdateProfileHandler)
 
 	studyRoomRoutes := router.Group("/study-room")
 	studyRoomRoutes.Use(middlewares.JWTValidationMiddleware())

--- a/backend-go/srcs/middlewares/jwt.go
+++ b/backend-go/srcs/middlewares/jwt.go
@@ -16,7 +16,7 @@ func JWTValidationMiddleware() gin.HandlerFunc {
 	return func(reqContext *gin.Context) {
 		err := token.ValidateJWTToken(reqContext)
 		if err != nil {
-			reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to validate JWT"})
+			reqContext.JSON(http.StatusUnauthorized, gin.H{"Error": "Failed to validate JWT"})
 			reqContext.Error(err)
 			reqContext.Abort()
 			return

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -108,7 +108,7 @@ func GetUserInfo(reqContext *gin.Context) {
 	*/
 	userId, err := token.ExtractUserIdFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusUnauthorized, gin.H{"error": "Failed to get user id from token"})
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"Error": "Failed to get user id from token"})
 		reqContext.Error(err)
 		return
 	}
@@ -116,12 +116,12 @@ func GetUserInfo(reqContext *gin.Context) {
 	user := &TUser{}
 	err = DB.First(&user, userId).Error
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
 	reqContext.JSON(http.StatusOK, gin.H{
-		"user": user.PrepareOutput(),
+		"User": user.PrepareOutput(),
 	})
 }

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -21,8 +21,10 @@ type TUser struct {
 	Password     string     `gorm:"type:varchar(60);not null;column:password"`
 	DisplayName  string     `gorm:"type:varchar(20);not null;column:display_name"`
 	IconImageURL string     `gorm:"type:varchar(255);column:icon_image_url"`
+	Introduction string     `gorm:"type:varchar(255);column:introduction"`
+	TownName     string     `gorm:"type:varchar(30);column:town_name"`
+	CoinCount    int        `gorm:"type:int;not null;column:coin_count"`
 	CreatedAt    time.Time  `gorm:"type:timestamp;default:CURRENT_TIMESTAMP;column:created_at"`
-	UpdatedAt    time.Time  `gorm:"type:timestamp;default:CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;column:updated_at"`
 	Works        []TWork    `gorm:"foreignKey:UserID;references:ID" json:"-"`
 	WorkLogs     []TWorkLog `gorm:"foreignKey:UserID;references:ID" json:"-"`
 }
@@ -55,9 +57,11 @@ func (user *TUser) CreateUser() (*TUser, error) {
 	if user.CreatedAt.IsZero() {
 		user.CreatedAt = time.Now().In(location)
 	}
-	if user.UpdatedAt.IsZero() {
-		user.UpdatedAt = time.Now().In(location)
-	}
+
+	user.TownName = user.DisplayName + "の町"
+	user.CoinCount = 0
+	user.Introduction = ""
+
 	err = DB.Create(user).Error
 	if err != nil {
 		return nil, err

--- a/backend-go/srcs/password/forgot.go
+++ b/backend-go/srcs/password/forgot.go
@@ -1,0 +1,115 @@
+package password
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"os"
+	"srcs/auth"
+	"srcs/mail"
+	"srcs/mail_contents"
+	"srcs/utils"
+	"sync"
+	"time"
+)
+
+type ForgotPasswordInput struct {
+	/*
+	 パスワードを忘れた際に送るリクエストに対するハンドラー関数
+	*/
+	Email string `json:"Email" binding:"required"`
+}
+
+var (
+	ForgotEmailOTPPairsMutex sync.Mutex
+	ForgotEmailOTPPairs      = make(map[string]auth.OTPEntry)
+)
+
+func saveOTP(OTP string, email string) error {
+	/*
+		OTPを保存する関数
+	*/
+	timeZone := os.Getenv("TIME_ZONE")
+	location, err := time.LoadLocation(timeZone)
+	if err != nil {
+		return err
+	}
+
+	ForgotEmailOTPPairsMutex.Lock()
+	defer ForgotEmailOTPPairsMutex.Unlock()
+	ForgotEmailOTPPairs[email] = auth.OTPEntry{
+		OTP:        OTP,
+		IsVerified: false,
+		CreatedAt:  time.Now().In(location),
+	}
+
+	return nil
+}
+
+func cleanupExpiredOTPs() error {
+	/*
+		期限切れのOTPを削除する関数
+	*/
+	timeZone := os.Getenv("TIME_ZONE")
+	location, err := time.LoadLocation(timeZone)
+	if err != nil {
+		return err
+	}
+
+	ForgotEmailOTPPairsMutex.Lock()
+	defer ForgotEmailOTPPairsMutex.Unlock()
+	for email, aOTPEntry := range ForgotEmailOTPPairs {
+		elapsedTime := time.Now().In(location).Sub(aOTPEntry.CreatedAt)
+		if elapsedTime > 30*time.Minute {
+			if os.Getenv("ENVIRONMENT") == "development" {
+				fmt.Println("Deleting expired OTP:", email)
+			}
+			delete(ForgotEmailOTPPairs, email)
+		}
+	}
+
+	return nil
+}
+
+func ForgotPasswordHandler(reqContext *gin.Context) {
+	/*
+		パスワードを忘れた際に送るリクエストに対するハンドラー関数。
+		ワンタイムパスワードを生成してそのメールアドレスに送信する。
+	*/
+	OTP, err := utils.GenerateRandomCode(6)
+	if err != nil {
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate OTP"})
+		reqContext.Error(err)
+		return
+	}
+
+	var forgotPasswordInput ForgotPasswordInput
+	if err = reqContext.ShouldBind(&forgotPasswordInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
+		return
+	}
+
+	if err = mail.SendMail(forgotPasswordInput.Email, mail_contents.CreatePasswordForgotSubject(), mail_contents.CreatePasswordForgotMailText(OTP), mail_contents.CreatePasswordForgotMailHTML(OTP)); err != nil {
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send email"})
+		reqContext.Error(err)
+		return
+	}
+
+	if err = saveOTP(OTP, forgotPasswordInput.Email); err != nil {
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save OTP"})
+		reqContext.Error(err)
+		return
+	}
+
+	if err = cleanupExpiredOTPs(); err != nil {
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cleanup expired OTPs"})
+		reqContext.Error(err)
+		return
+	}
+
+	if os.Getenv("ENVIRONMENT") == "development" {
+		reqContext.JSON(http.StatusCreated, gin.H{"OTP": OTP})
+	}
+	reqContext.Status(http.StatusCreated)
+}

--- a/backend-go/srcs/password/forgot.go
+++ b/backend-go/srcs/password/forgot.go
@@ -78,32 +78,32 @@ func ForgotPasswordHandler(reqContext *gin.Context) {
 	*/
 	OTP, err := utils.GenerateRandomCode(6)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to generate OTP"})
 		reqContext.Error(err)
 		return
 	}
 
 	var forgotPasswordInput ForgotPasswordInput
 	if err = reqContext.ShouldBind(&forgotPasswordInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	if err = mail.SendMail(forgotPasswordInput.Email, mail_contents.CreatePasswordForgotSubject(), mail_contents.CreatePasswordForgotMailText(OTP), mail_contents.CreatePasswordForgotMailHTML(OTP)); err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send email"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to send email"})
 		reqContext.Error(err)
 		return
 	}
 
 	if err = saveOTP(OTP, forgotPasswordInput.Email); err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save OTP"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to save OTP"})
 		reqContext.Error(err)
 		return
 	}
 
 	if err = cleanupExpiredOTPs(); err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cleanup expired OTPs"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to cleanup expired OTPs"})
 		reqContext.Error(err)
 		return
 	}

--- a/backend-go/srcs/password/reset.go
+++ b/backend-go/srcs/password/reset.go
@@ -1,0 +1,97 @@
+package password
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+	"net/http"
+	"os"
+	"srcs/models"
+	"time"
+)
+
+func verifyOTP(resetPasswordInput ResetPasswordInput) error {
+	/*
+		OTPを認証する関数
+		OTPが存在しない、一致しない、期限を超過している時にエラーを返す。
+	*/
+	ForgotEmailOTPPairsMutex.Lock()
+	defer ForgotEmailOTPPairsMutex.Unlock()
+
+	aOTPEntry, isExist := ForgotEmailOTPPairs[resetPasswordInput.Email]
+	if !isExist {
+		return errors.New(fmt.Sprintf("OTP %s does not exist", resetPasswordInput.Email))
+	}
+
+	if resetPasswordInput.OTP != aOTPEntry.OTP {
+		return errors.New(fmt.Sprintf("OTP %s does not match", resetPasswordInput.OTP))
+	}
+
+	timeZone := os.Getenv("TIME_ZONE")
+	location, err := time.LoadLocation(timeZone)
+	if err != nil {
+		return err
+	}
+	elapsedTime := time.Now().In(location).Sub(aOTPEntry.CreatedAt)
+	if elapsedTime > 5*time.Minute {
+		delete(ForgotEmailOTPPairs, resetPasswordInput.Email)
+		return errors.New(fmt.Sprintf("The OTP has already expired."))
+	}
+
+	delete(ForgotEmailOTPPairs, resetPasswordInput.Email)
+	return nil
+}
+
+func resetPassword(resetPasswordInput ResetPasswordInput) error {
+	/*
+		DBのパスワードを更新する関数。
+	*/
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(resetPasswordInput.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+
+	if err := models.DB.Model(&models.TUser{}).Where("email = ?", resetPasswordInput.Email).Update("password", string(hashedPassword)).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ResetPasswordInput struct {
+	/*
+		パスワードリセットリクエスト時に抽出するJSONデータの構造体
+	*/
+	Email       string `json:"Email" binding:"required"`
+	OTP         string `json:"OTP" binding:"required"`
+	NewPassword string `json:"NewPassword" binding:"required"`
+}
+
+func ResetPasswordHandler(reqContext *gin.Context) {
+	/*
+		パスワードリセットリクエストに対するハンドラー関数。
+		ワンタイムパスワードと共に設定したいパスワードを受け取って、
+		ユーザーのパスワードを更新する。
+	*/
+	var resetPasswordInput ResetPasswordInput
+	if err := reqContext.ShouldBind(&resetPasswordInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
+		return
+	}
+
+	if err := verifyOTP(resetPasswordInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "OTP does not match"})
+		reqContext.Error(err)
+		return
+	}
+
+	if err := resetPassword(resetPasswordInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to reset password."})
+		reqContext.Error(err)
+		return
+	}
+
+	reqContext.Status(http.StatusOK)
+}

--- a/backend-go/srcs/password/reset.go
+++ b/backend-go/srcs/password/reset.go
@@ -76,19 +76,19 @@ func ResetPasswordHandler(reqContext *gin.Context) {
 	*/
 	var resetPasswordInput ResetPasswordInput
 	if err := reqContext.ShouldBind(&resetPasswordInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	if err := verifyOTP(resetPasswordInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "OTP does not match"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "OTP does not match"})
 		reqContext.Error(err)
 		return
 	}
 
 	if err := resetPassword(resetPasswordInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to reset password."})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to reset password."})
 		reqContext.Error(err)
 		return
 	}

--- a/backend-go/srcs/profile/get.go
+++ b/backend-go/srcs/profile/get.go
@@ -17,5 +17,5 @@ func GetProfileHandler(reqContext *gin.Context) {
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, user.PrepareOutput())
+	reqContext.JSON(http.StatusOK, gin.H{"user": user.PrepareOutput()})
 }

--- a/backend-go/srcs/profile/get.go
+++ b/backend-go/srcs/profile/get.go
@@ -1,0 +1,21 @@
+package profile
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"srcs/utils"
+)
+
+func GetProfileHandler(reqContext *gin.Context) {
+	/*
+		ユーザーのプロフィールを取得するリクエストに対するハンドラー関数
+	*/
+	user, err := utils.ExtractUserFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not found"})
+		reqContext.Error(err)
+		return
+	}
+
+	reqContext.JSON(http.StatusOK, user.PrepareOutput())
+}

--- a/backend-go/srcs/profile/get.go
+++ b/backend-go/srcs/profile/get.go
@@ -12,10 +12,10 @@ func GetProfileHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"user": user.PrepareOutput()})
+	reqContext.JSON(http.StatusOK, gin.H{"User": user.PrepareOutput()})
 }

--- a/backend-go/srcs/profile/update.go
+++ b/backend-go/srcs/profile/update.go
@@ -51,24 +51,24 @@ func UpdateProfileHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not authenticated"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not authenticated"})
 		reqContext.Error(err)
 		return
 	}
 
 	var updateProfileInput UpdateProfileInput
 	if err := reqContext.BindJSON(&updateProfileInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = UpdateProfile(user, updateProfileInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to update profile"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to update profile"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"user": user.PrepareOutput()})
+	reqContext.JSON(http.StatusOK, gin.H{"User": user.PrepareOutput()})
 }

--- a/backend-go/srcs/profile/update.go
+++ b/backend-go/srcs/profile/update.go
@@ -70,5 +70,5 @@ func UpdateProfileHandler(reqContext *gin.Context) {
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, user.PrepareOutput())
+	reqContext.JSON(http.StatusOK, gin.H{"user": user.PrepareOutput()})
 }

--- a/backend-go/srcs/profile/update.go
+++ b/backend-go/srcs/profile/update.go
@@ -1,0 +1,74 @@
+package profile
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"srcs/models"
+	"srcs/utils"
+)
+
+func UpdateProfile(user *models.TUser, updateProfileInput UpdateProfileInput) error {
+	/*
+		DBのユーザーの情報を更新をする関数
+	*/
+	updates := map[string]interface{}{}
+
+	if updateProfileInput.DisplayName != "" {
+		updates["display_name"] = updateProfileInput.DisplayName
+	}
+	if updateProfileInput.IconImageURL != "" {
+		updates["icon_image_url"] = updateProfileInput.IconImageURL
+	}
+	if updateProfileInput.Introduction != nil {
+		updates["introduction"] = *updateProfileInput.Introduction
+	}
+	if updateProfileInput.TownName != "" {
+		updates["town_name"] = updateProfileInput.TownName
+	}
+
+	if len(updates) > 0 {
+		if err := models.DB.Model(user).Updates(updates).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type UpdateProfileInput struct {
+	/*
+		ユーザーのプロフィールを更新するリクエスト時に抽出するJSONデータの構造体
+	*/
+	DisplayName  string  `json:"DisplayName"`
+	IconImageURL string  `json:"IconImageUrl"`
+	Introduction *string `json:"Introduction"`
+	TownName     string  `json:"TownName"`
+}
+
+func UpdateProfileHandler(reqContext *gin.Context) {
+	/*
+		ユーザーのプロフィールを更新するリクエストに対するハンドラー関数
+	*/
+	user, err := utils.ExtractUserFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not authenticated"})
+		reqContext.Error(err)
+		return
+	}
+
+	var updateProfileInput UpdateProfileInput
+	if err := reqContext.BindJSON(&updateProfileInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.Error(err)
+		return
+	}
+
+	err = UpdateProfile(user, updateProfileInput)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to update profile"})
+		reqContext.Error(err)
+		return
+	}
+
+	reqContext.JSON(http.StatusOK, user.PrepareOutput())
+}

--- a/backend-go/srcs/reports/submit.go
+++ b/backend-go/srcs/reports/submit.go
@@ -83,8 +83,8 @@ type SubmitReportInput struct {
 	/*
 		運営への報告リクエスト時に抽出するJSONデータの構造体
 	*/
-	Type string `json:"type" binding:"required"`
-	Text string `json:"text" binding:"required"`
+	Type string `json:"Type" binding:"required"`
+	Text string `json:"Text" binding:"required"`
 }
 
 func SubmitReportsHandler(reqContext *gin.Context) {
@@ -93,28 +93,28 @@ func SubmitReportsHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
 	var submitReportInput SubmitReportInput
 	if err := reqContext.ShouldBindJSON(&submitReportInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = sendReportEmailToAdmin(*user, submitReportInput)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send email to admin"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to send email to admin"})
 		reqContext.Error(err)
 		return
 	}
 
 	err = sendReportEmailToUser(*user, submitReportInput)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send email to user"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to send email to user"})
 		reqContext.Error(err)
 		return
 	}

--- a/backend-go/srcs/study_room/create.go
+++ b/backend-go/srcs/study_room/create.go
@@ -82,21 +82,21 @@ func CreateStudyRoomHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
 	var createStudyRoomInput CreateStudyRoomInput
 	if err := reqContext.ShouldBindJSON(&createStudyRoomInput); err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Invalid json input"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
 		reqContext.Error(err)
 		return
 	}
 
 	roomCode, err := generateRoomCode()
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"status": "Failed to generate room code"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Status": "Failed to generate room code"})
 		reqContext.Error(err)
 		return
 	}
@@ -104,5 +104,5 @@ func CreateStudyRoomHandler(reqContext *gin.Context) {
 	StudyRoomsMutex.Lock()
 	StudyRooms[roomCode] = createStudyRoom(createStudyRoomInput, *user)
 	StudyRoomsMutex.Unlock()
-	reqContext.JSON(http.StatusOK, gin.H{"roomCode": roomCode})
+	reqContext.JSON(http.StatusOK, gin.H{"RoomCode": roomCode})
 }

--- a/backend-go/srcs/study_room/delete.go
+++ b/backend-go/srcs/study_room/delete.go
@@ -29,7 +29,7 @@ func DeleteStudyRoomHandler(reqContext *gin.Context) {
 	*/
 	userId, err := token.ExtractUserIdFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusUnauthorized, gin.H{"status": "Failed to extract user id"})
+		reqContext.JSON(http.StatusUnauthorized, gin.H{"Error": "Failed to extract user id"})
 		reqContext.Error(err)
 		return
 	}
@@ -37,5 +37,5 @@ func DeleteStudyRoomHandler(reqContext *gin.Context) {
 	StudyRoomsMutex.Lock()
 	deleteStudyRoomByHostId(int(userId))
 	StudyRoomsMutex.Unlock()
-	reqContext.JSON(http.StatusOK, gin.H{"status": "Delete Success"})
+	reqContext.Status(http.StatusOK)
 }

--- a/backend-go/srcs/study_room/join.go
+++ b/backend-go/srcs/study_room/join.go
@@ -47,7 +47,7 @@ func JoinStudyRoomHandler(reqContext *gin.Context) {
 	roomCode := reqContext.Param("roomCode")
 	StudyRoomsMutex.Lock()
 	if _, isExist := StudyRooms[roomCode]; !isExist {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "room code not exist"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "room code not exist"})
 		return
 	}
 	room := StudyRooms[roomCode]
@@ -56,7 +56,7 @@ func JoinStudyRoomHandler(reqContext *gin.Context) {
 	// JWTトークンからuserIdを抽出し、userをDBから取り出す。
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
@@ -64,7 +64,7 @@ func JoinStudyRoomHandler(reqContext *gin.Context) {
 	// Websocketへupgradeする。
 	conn, err := upgrader.Upgrade(reqContext.Writer, reqContext.Request, nil)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to upgrade connection"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to upgrade connection"})
 		reqContext.Error(err)
 		return
 	}

--- a/backend-go/srcs/works/add.go
+++ b/backend-go/srcs/works/add.go
@@ -32,7 +32,7 @@ func AddWorkHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
@@ -40,17 +40,17 @@ func AddWorkHandler(reqContext *gin.Context) {
 	var addWorkInput AddWorkInput
 	err = reqContext.ShouldBindJSON(&addWorkInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to bind JSON"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to bind JSON"})
 		reqContext.Error(err)
 		return
 	}
 
 	work, err := addWork(addWorkInput, *user)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to add work"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to add work"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"work": work})
+	reqContext.JSON(http.StatusOK, gin.H{"Work": work})
 }

--- a/backend-go/srcs/works/get.go
+++ b/backend-go/srcs/works/get.go
@@ -22,17 +22,17 @@ func GetWorksHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
 	works, err := getWorks(*user)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"works": works})
+	reqContext.JSON(http.StatusOK, gin.H{"Works": works})
 }

--- a/backend-go/srcs/works/log_get.go
+++ b/backend-go/srcs/works/log_get.go
@@ -26,17 +26,17 @@ func GetWorkLogsHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
 
 	workLogs, err := getWorkLogs(*user)
 	if err != nil {
-		reqContext.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get work logs"})
+		reqContext.JSON(http.StatusInternalServerError, gin.H{"Error": "Failed to get work logs"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"workLogs": workLogs})
+	reqContext.JSON(http.StatusOK, gin.H{"WorkLogs": workLogs})
 }

--- a/backend-go/srcs/works/log_post.go
+++ b/backend-go/srcs/works/log_post.go
@@ -45,7 +45,7 @@ func LogWorkHandler(reqContext *gin.Context) {
 	*/
 	user, err := utils.ExtractUserFromRequest(reqContext)
 	if err != nil {
-		reqContext.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		reqContext.JSON(http.StatusNotFound, gin.H{"Error": "User not found"})
 		reqContext.Error(err)
 		return
 	}
@@ -53,17 +53,17 @@ func LogWorkHandler(reqContext *gin.Context) {
 	var logWorkInput LogWorkInput
 	err = reqContext.ShouldBind(&logWorkInput)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to bind request"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to bind request"})
 		reqContext.Error(err)
 		return
 	}
 
 	workLog, err := logWork(logWorkInput, *user)
 	if err != nil {
-		reqContext.JSON(http.StatusBadRequest, gin.H{"error": "Failed to get work log"})
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to get work log"})
 		reqContext.Error(err)
 		return
 	}
 
-	reqContext.JSON(http.StatusOK, gin.H{"workLog": workLog})
+	reqContext.JSON(http.StatusOK, gin.H{"WorkLog": workLog})
 }

--- a/db-mysql/docs/database.dbml
+++ b/db-mysql/docs/database.dbml
@@ -12,8 +12,10 @@ Table t_users {
   password varchar(60)
   display_name varchar(20)
   icon_image_url varchar(255)
+  introduction varchar(200)
+  town_name varchar(30)
+  coin_count integer
   created_at timestamp
-  updated_at timestamp
 }
 
 

--- a/postman/user.json
+++ b/postman/user.json
@@ -42,7 +42,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"email\": \"test@test.com\"\n}",
+          "raw": "{\n    \"Email\": \"test@test.com\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -90,7 +90,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"email\": \"test@test.com\",\n    \"otp\": \"{{otp}}\"\n}",
+          "raw": "{\n    \"Email\": \"test@test.com\",\n    \"OTP\": \"{{otp}}\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -129,8 +129,8 @@
               "let jsonData = pm.response.json();",
               "",
               "// user_data の存在を確認",
-              "pm.test(\"レスポンスに user_data が含まれている\", function () {",
-              "    pm.expect(jsonData).to.have.property(\"user\");",
+              "pm.test(\"レスポンスに User が含まれている\", function () {",
+              "    pm.expect(jsonData).to.have.property(\"User\");",
               "});",
               ""
             ],
@@ -185,12 +185,12 @@
               "});",
               "",
               "// \"token\" キーがレスポンスに含まれていることを確認し、その値を環境変数に保存",
-              "pm.test('\"token\" キーが含まれていることを確認', function () {",
+              "pm.test('\"Token\" キーが含まれていることを確認', function () {",
               "    var jsonData = pm.response.json();",
-              "    pm.expect(jsonData).to.have.property(\"token\");",
+              "    pm.expect(jsonData).to.have.property(\"Token\");",
               "",
               "    // tokenの値を環境変数に保存",
-              "    pm.environment.set(\"jwt_token\", jsonData.token);",
+              "    pm.environment.set(\"jwt_token\", jsonData.Token);",
               "});",
               ""
             ],
@@ -238,9 +238,9 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにuserフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにUserフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('user');",
+              "    pm.expect(jsonResponse).to.have.property('User');",
               "});",
               ""
             ],
@@ -293,9 +293,9 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにuserフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにUserフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('user');",
+              "    pm.expect(jsonResponse).to.have.property('User');",
               "});",
               ""
             ],
@@ -339,11 +339,11 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにroomCodeフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにRoomCodeフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('roomCode');",
+              "    pm.expect(jsonResponse).to.have.property('RoomCode');",
               "",
-              "    pm.environment.set(\"roomCode\", jsonResponse.roomCode);",
+              "    pm.environment.set(\"roomCode\", jsonResponse.RoomCode);",
               "});",
               ""
             ],
@@ -437,9 +437,9 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにworkフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにWorkフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('work');",
+              "    pm.expect(jsonResponse).to.have.property('Work');",
               "});",
               ""
             ],
@@ -492,9 +492,9 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにworksフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにWorksフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('works');",
+              "    pm.expect(jsonResponse).to.have.property('Works');",
               "});",
               ""
             ],
@@ -540,7 +540,7 @@
               "",
               "pm.test(\"レスポンスのJSONにworkLogフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('workLog');",
+              "    pm.expect(jsonResponse).to.have.property('WorkLog');",
               "});",
               ""
             ],
@@ -593,9 +593,9 @@
               "    pm.response.to.have.status(200);",
               "});",
               "",
-              "pm.test(\"レスポンスのJSONにworkLogsフィールドが含まれていること\", function() {",
+              "pm.test(\"レスポンスのJSONにWorkLogsフィールドが含まれていること\", function() {",
               "    var jsonResponse = pm.response.json();",
-              "    pm.expect(jsonResponse).to.have.property('workLogs');",
+              "    pm.expect(jsonResponse).to.have.property('WorkLogs');",
               "});",
               ""
             ],

--- a/postman/user.json
+++ b/postman/user.json
@@ -228,6 +228,107 @@
       "response": []
     },
     {
+      "name": "プロフィール更新 Copy",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"レスポンスコードが200であること\", function() {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"レスポンスのJSONにuserフィールドが含まれていること\", function() {",
+              "    var jsonResponse = pm.response.json();",
+              "    pm.expect(jsonResponse).to.have.property('user');",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": " Bearer {{jwt_token}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"DisplayName\": \"UPDATEMAN\",\n    \"IconImageURL\": \"update_url\",\n    \"Introduction\": \"こんにちは\",\n    \"TownName\": \"マサラタウン\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/profile/update",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "profile",
+            "update"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "プロフィール取得 Copy",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"レスポンスコードが200であること\", function() {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"レスポンスのJSONにuserフィールドが含まれていること\", function() {",
+              "    var jsonResponse = pm.response.json();",
+              "    pm.expect(jsonResponse).to.have.property('user');",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": " Bearer {{jwt_token}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8080/profile/get",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "profile",
+            "get"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "自習室作成 Copy",
       "event": [
         {
@@ -522,6 +623,108 @@
           "path": [
             "works",
             "log"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "パスワード忘れ(開発環境)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// ステータスコードが 201 であることを確認",
+              "pm.test(\"ステータスコードが 201\", function () {",
+              "    pm.response.to.have.status(201);",
+              "});",
+              "",
+              "// レスポンスを JSON として取得",
+              "let jsonData = pm.response.json();",
+              "",
+              "// OTP の存在を確認",
+              "pm.test(\"レスポンスに OTP が含まれている\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"OTP\");",
+              "",
+              "    // OTPの値を環境変数に保存",
+              "    pm.environment.set(\"passwordOTP\", jsonData.OTP);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"Email\": \"test@test.com\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/password/forgot",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "password",
+            "forgot"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "パスワードリセット(開発環境)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// ステータスコードが 200 であることを確認",
+              "pm.test(\"ステータスコードが 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"Email\": \"test@test.com\",\n    \"OTP\": \"{{passwordOTP}}\",\n    \"NewPassword\": \"NewPassword\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/password/reset",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "password",
+            "reset"
           ]
         }
       },


### PR DESCRIPTION
**説明**
プロフィールに関する以下のAPIを実装しました。
・プロフィール取得API
・プロフィール更新API
・パスワード変更API(特殊)

パスワード変更については簡単に変更できないように確認方法で書くような特殊な実装にしました。

また、これらについてCIを追加しました。

**確認方法**
.env.prodを作成してください。
```
docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
```
で起動し、postmanで以下を順に実行してください。
1.右上の「環境なし」を「matcha」に変更
2.「OTP生成」のボディのemailの値をご自身のアドレスにして送信
3.「OTP認証」のemailとotpを先ほど届いたメールの内容に変更して送信
4.「ユーザー登録」のEmailをご自身のアドレスにして送信
5.「ログイン」を送信
6.「プロフィール取得」を送信
7.「プロフィール更新」をデータを好きな内容にして送信
8.「プロフィール取得」でデータが更新されていることを確認する。
9.「パスワード忘れ」のEmailをご自身のアドレスにして送信してメールが届く。
10.「パスワードリセット」のEmailをご自身の、OTPをメールの内容(9で届いたメール、OTP生成のものとは別物)、NewPasswordを新しく設定したいパスワードにして送信
11.「ログイン」でパスワードを新しいものにしないとうまくいかないことを確認