### PR TITLE
[Feature] ストアでの建物購入APIを作成しました

### DIFF
--- a/.github/workflows/backend-api-test.yml
+++ b/.github/workflows/backend-api-test.yml
@@ -28,6 +28,8 @@ jobs:
           echo "ADMIN_EMAIL_PASSWORD=${{ secrets.ADMIN_EMAIL_PASSWORD }}" >> .env
           echo "ADMIN_USERNAME=${{ secrets.ADMIN_USERNAME }}" >> .env
           echo "ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}" >> .env
+          echo "MINUTES_PER_INTERVAL=${{ secrets.MINUTES_PER_INTERVAL }}" >> .env
+          echo "COIN_COUNT_PER_INTERVAL=${{ secrets.COIN_COUNT_PER_INTERVAL }}" >> .env
           echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> .env
           echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
           echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
@@ -77,6 +79,9 @@ jobs:
 
       - name: Test Buildings API
         run: newman run ./postman/buildings.json --reporters cli,junit --reporter-junit-export results.xml
+
+      - name: Test Store API
+        run: newman run ./postman/store.json --reporters cli,junit --reporter-junit-export results.xml
 
       - name: Test Password API
         run: newman run ./postman/password.json --reporters cli,junit --reporter-junit-export results.xml

--- a/backend-go/json_data/buildings/hajimari.json
+++ b/backend-go/json_data/buildings/hajimari.json
@@ -5,13 +5,13 @@
     "DefaultName": "はじまりの店",
     "RequiredCoinCount": 200,
     "SaleStartTime": "2025-03-26T00:00:00+09:00",
-    "IsInStore": true
+    "SaleEndTime": "2025-05-26T00:00:00+09:00"
   },{
     "ExteriorImageURL": "hajimarinotyugakko_exterior_url",
     "InteriorImageURL": "hajimarinotyugakko_interior_url",
     "DefaultName": "はじまりの中学校",
     "RequiredCoinCount": 200,
     "SaleStartTime": "2025-03-26T00:00:00+09:00",
-    "IsInStore": true
+    "SaleEndTime": "2025-05-26T00:00:00+09:00"
   }]
 }

--- a/backend-go/srcs/admin/set_in_store.go
+++ b/backend-go/srcs/admin/set_in_store.go
@@ -29,7 +29,7 @@ func setBuildingsInStore(setBuildingsInStoreInput SetBuildingsInStoreInput) erro
 			DefaultName:       inputBuilding.DefaultName,
 			CustomName:        "",
 			RequiredCoinCount: inputBuilding.RequiredCoinCount,
-			IsInStore:         inputBuilding.IsInStore,
+			IsInStore:         utils.IsOnSale(inputBuilding.SaleStartTime, inputBuilding.SaleEndTime),
 			SaleStartTime:     utils.ConvertToNullTime(inputBuilding.SaleStartTime),
 			SaleEndTime:       utils.ConvertToNullTime(inputBuilding.SaleEndTime),
 		}
@@ -50,7 +50,6 @@ type BuildingInfo struct {
 	InteriorImageURL  string    `json:"InteriorImageUrl" binding:"required"`
 	DefaultName       string    `json:"DefaultName" binding:"required"`
 	RequiredCoinCount int       `json:"RequiredCoinCount" binding:"required"`
-	IsInStore         bool      `json:"IsInStore" binding:"required"`
 	SaleStartTime     time.Time `json:"SaleStartTime"`
 	SaleEndTime       time.Time `json:"SaleEndTime"`
 }

--- a/backend-go/srcs/buildings/get_store.go
+++ b/backend-go/srcs/buildings/get_store.go
@@ -1,0 +1,65 @@
+package buildings
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"srcs/models"
+	"srcs/utils"
+)
+
+func getBuildingsInStore() ([]models.TBuilding, error) {
+	/*
+		ストアで販売中の建物一覧を返す。
+	*/
+	var storeBuildings []models.TBuilding
+	err := models.DB.Where("is_in_store = true").Find(&storeBuildings).Error
+
+	return storeBuildings, err
+}
+
+func getNonOwnedBuildingsInStore(user models.TUser) ([]models.TBuilding, error) {
+	/*
+		ストアで販売中の建物一覧を返す。
+	*/
+	buildingsInStore, err := getBuildingsInStore()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("buildingsInStore", buildingsInStore)
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!")
+
+	ownBuildings, err := GetOwnBuildings(user)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("ownBuildings", ownBuildings)
+
+	for _, ownBuilding := range ownBuildings {
+		buildingsInStore = utils.RemoveElementFromTBuilding(buildingsInStore, ownBuilding.ID)
+	}
+
+	return buildingsInStore, nil
+}
+
+func GetNonOwnedBuildingsInStoreHandler(reqContext *gin.Context) {
+	/*
+		ストアで販売中の建物一覧を取得するリクエストに対するハンドラー関数
+		ユーザーがすでに所有している建物を除く。
+	*/
+	user, err := utils.ExtractUserFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not found"})
+		reqContext.Error(err)
+		return
+	}
+
+	nonOwnedBuildingsInStore, err := getNonOwnedBuildingsInStore(*user)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Error in getting store buildings"})
+		reqContext.Error(err)
+		return
+	}
+
+	reqContext.JSON(http.StatusOK, gin.H{"Buildings": nonOwnedBuildingsInStore})
+}

--- a/backend-go/srcs/coins/calculate.go
+++ b/backend-go/srcs/coins/calculate.go
@@ -1,0 +1,19 @@
+package coins
+
+import (
+	"math"
+	"os"
+	"strconv"
+)
+
+func CalculateCoinCountFromStudyMinutes(minutes int64) int {
+	/*
+		勉強に応じたコイン枚数を計算する関数
+	*/
+	minutesPerInterval, _ := strconv.ParseFloat(os.Getenv("MINUTES_PER_INTERVAL"), 64)
+	coinCountPerInterval, _ := strconv.ParseFloat(os.Getenv("COIN_COUNT_PER_INTERVAL"), 64)
+
+	IntervalCount := math.Floor(float64(minutes) / minutesPerInterval)
+	coinCount := IntervalCount * coinCountPerInterval
+	return int(coinCount)
+}

--- a/backend-go/srcs/coins/give_user.go
+++ b/backend-go/srcs/coins/give_user.go
@@ -1,0 +1,20 @@
+package coins
+
+import (
+	"errors"
+	"math"
+	"srcs/models"
+)
+
+func GiveUserCoins(user models.TUser, coinCountToGive int) error {
+	/*
+		ユーザーにコインを与える関数
+	*/
+	if user.CoinCount >= math.MaxInt-coinCountToGive {
+		return errors.New("coinCountToGive exceeded")
+	}
+
+	user.CoinCount += coinCountToGive
+	err := models.DB.Save(&user).Error
+	return err
+}

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -107,6 +107,7 @@ func main() {
 	buildingsRoutes.Use(middlewares.JWTValidationMiddleware())
 	buildingsRoutes.GET("/get-own", buildings.GetOwnBuildingsHandler)
 	buildingsRoutes.GET("/get-town", buildings.GetTownBuildingsHandler)
+	buildingsRoutes.GET("/get-store", buildings.GetNonOwnedBuildingsInStoreHandler)
 	buildingsRoutes.POST("/build", buildings.BuildBuildingsHandler)
 
 	adminGroup := router.Group("/admin")

--- a/backend-go/srcs/main.go
+++ b/backend-go/srcs/main.go
@@ -12,6 +12,7 @@ import (
 	"srcs/password"
 	"srcs/profile"
 	"srcs/reports"
+	"srcs/store"
 	"srcs/study_room"
 	"srcs/utils"
 	"srcs/works"
@@ -109,6 +110,10 @@ func main() {
 	buildingsRoutes.GET("/get-town", buildings.GetTownBuildingsHandler)
 	buildingsRoutes.GET("/get-store", buildings.GetNonOwnedBuildingsInStoreHandler)
 	buildingsRoutes.POST("/build", buildings.BuildBuildingsHandler)
+
+	storeRoutes := router.Group("/store")
+	storeRoutes.Use(middlewares.JWTValidationMiddleware())
+	storeRoutes.POST("/buy", store.BuyBuildingHandler)
 
 	adminGroup := router.Group("/admin")
 	adminGroup.Use(middlewares.AdminJWTValidationMiddleware())

--- a/backend-go/srcs/models/users.go
+++ b/backend-go/srcs/models/users.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 	"net/http"
 	"os"
 	"srcs/token"
@@ -41,6 +43,25 @@ func (*TUser) TableName() string {
 		AutoMigrateの際に自動で参照される。
 	*/
 	return "t_users"
+}
+
+func (user *TUser) DeductCoins(requiredCoinCount int) error {
+	if user.CoinCount < requiredCoinCount {
+		return errors.New("Not enough coins")
+	}
+	user.CoinCount -= requiredCoinCount
+	err := DB.Save(&user).Error
+	return err
+}
+
+func (user *TUser) IsBuildingIDOwned(buildingID int) (bool, error) {
+	err := DB.Where("t_building_id = ? AND t_user_id = ?", buildingID, user.ID).First(&TUserBuilding{}).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (user *TUser) CreateUser() (*TUser, error) {

--- a/backend-go/srcs/store/buy.go
+++ b/backend-go/srcs/store/buy.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"srcs/models"
+	"srcs/utils"
+)
+
+func BuyBuilding(user *models.TUser, buildingID int) error {
+	var building models.TBuilding
+	err := models.DB.Where("id = ?", buildingID).First(&building).Error
+	if err != nil {
+		return err
+	}
+
+	err = user.DeductCoins(building.RequiredCoinCount)
+	if err != nil {
+		return err
+	}
+
+	userBuilding := &models.TUserBuilding{
+		UserID:     user.ID,
+		BuildingID: buildingID,
+		PlaceIndex: 0,
+	}
+
+	err = models.DB.Create(&userBuilding).Error
+	return err
+}
+
+type BuyBuildingInput struct {
+	BuildingID int `json:"BuildingID" binding:"required"`
+}
+
+func BuyBuildingHandler(reqContext *gin.Context) {
+	/*
+		建物を購入するリクエストに対するハンドラー関数
+	*/
+	user, err := utils.ExtractUserFromRequest(reqContext)
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "User not found"})
+		reqContext.Error(err)
+		return
+	}
+
+	var buyBuildingInput BuyBuildingInput
+	if err := reqContext.ShouldBindJSON(&buyBuildingInput); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid json input"})
+		reqContext.Error(err)
+		return
+	}
+
+	if isBuildingOwned, err := user.IsBuildingIDOwned(buyBuildingInput.BuildingID); !isBuildingOwned && err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Error in checking user ownership"})
+		reqContext.Error(err)
+		return
+	} else if isBuildingOwned {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "The building ID is owned"})
+	}
+
+	if err := BuyBuilding(user, buyBuildingInput.BuildingID); err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Error in buying building"})
+		reqContext.Error(err)
+		return
+	}
+
+	reqContext.Status(http.StatusOK)
+}

--- a/backend-go/srcs/utils/is_on_sale.go
+++ b/backend-go/srcs/utils/is_on_sale.go
@@ -1,0 +1,12 @@
+package utils
+
+import "time"
+
+func IsOnSale(saleStartTime time.Time, saleEndTime time.Time) bool {
+	/*
+		現在が販売時間かどうかを判定する関数
+	*/
+	currentTime, _ := ConvertToMyTimeZone(time.Now())
+
+	return currentTime.After(saleStartTime) && currentTime.Before(saleEndTime)
+}

--- a/backend-go/srcs/utils/slice.go
+++ b/backend-go/srcs/utils/slice.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"srcs/models"
+)
+
+func RemoveElementFromTBuilding(buildings []models.TBuilding, removeBuildingID int) []models.TBuilding {
+	/*
+		指定されたkeyの要素をスライスから削除する関数
+	*/
+	removeKey := -1
+
+	for key, building := range buildings {
+		if building.ID == removeBuildingID {
+			removeKey = key
+			break
+		}
+	}
+
+	if removeKey == -1 {
+		return buildings
+	}
+	return append(buildings[:removeKey], buildings[removeKey+1:]...)
+}

--- a/backend-go/srcs/works/log_post.go
+++ b/backend-go/srcs/works/log_post.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"os"
+	"srcs/coins"
 	"srcs/models"
 	"srcs/utils"
 	"time"
@@ -61,6 +62,13 @@ func LogWorkHandler(reqContext *gin.Context) {
 	workLog, err := logWork(logWorkInput, *user)
 	if err != nil {
 		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to get work log"})
+		reqContext.Error(err)
+		return
+	}
+
+	err = coins.GiveUserCoins(*user, coins.CalculateCoinCountFromStudyMinutes(logWorkInput.Minutes))
+	if err != nil {
+		reqContext.JSON(http.StatusBadRequest, gin.H{"Error": "Failed to give user coins"})
 		reqContext.Error(err)
 		return
 	}

--- a/postman/store.json
+++ b/postman/store.json
@@ -8,6 +8,66 @@
   },
   "item": [
     {
+      "name": "ログイン Copy",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// ステータスコードが200であることを確認",
+              "pm.test(\"レスポンスが 200 であることを確認\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "// レスポンスがJSON形式であることを確認",
+              "pm.test(\"レスポンスがJSONであることを確認\", function () {",
+              "    pm.response.to.be.json;",
+              "});",
+              "",
+              "// \"token\" キーがレスポンスに含まれていることを確認し、その値を環境変数に保存",
+              "pm.test('\"Token\" キーが含まれていることを確認', function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"Token\");",
+              "",
+              "    // tokenの値を環境変数に保存",
+              "    pm.environment.set(\"jwt_token\", jsonData.Token);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"Username\": \"test\",\n    \"Password\": \"test\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/auth/login",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "auth",
+            "login"
+          ]
+        },
+        "description": "**説明**\n\nユーザーのログイン処理を行うAPI。\n\n**JOSNデータ**\n\n``` json\n{\n    \"Username\": \"文字列\",\n    \"Email\": \"文字列\",// UsernameかEmailは必須(どちらも含んでも良い)\n    \"Password\": \"文字列\"// 必須\n}\n\n ```"
+      },
+      "response": []
+    },
+    {
       "name": "ストアにある建物一覧 Copy",
       "event": [
         {

--- a/postman/store.json
+++ b/postman/store.json
@@ -1,0 +1,107 @@
+{
+  "info": {
+    "_postman_id": "e17e344f-6483-4c19-8b65-03dab6c3ab0e",
+    "name": "CI(ストア)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "40190595",
+    "_collection_link": "https://matcha-0044.postman.co/workspace/Matcha%25E3%2583%25AF%25E3%2583%25BC%25E3%2582%25AF%25E3%2582%25B9%25E3%2583%259A%25E3%2583%25BC%25E3%2582%25B9~92830edc-e8ea-4a8f-8413-95d98177a966/collection/40190595-e17e344f-6483-4c19-8b65-03dab6c3ab0e?action=share&source=collection_link&creator=40190595"
+  },
+  "item": [
+    {
+      "name": "ストアにある建物一覧 Copy",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"レスポンスコードが200であること\", function() {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"レスポンスのJSONにBuildingsフィールドが含まれていること\", function() {",
+              "    var jsonResponse = pm.response.json();",
+              "    pm.expect(jsonResponse).to.have.property('Buildings');",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": " Bearer {{jwt_token}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8080/buildings/get-store",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "buildings",
+            "get-store"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "建物購入 Copy",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"レスポンスコードが200であること\", function() {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": " Bearer {{jwt_token}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"BuildingID\": 2\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/store/buy",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "store",
+            "buy"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/postman/work.json
+++ b/postman/work.json
@@ -201,7 +201,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"WorkID\": 1,\n    \"Minutes\": 100\n}",
+          "raw": "{\n    \"WorkID\": 1,\n    \"Minutes\": 1000\n}",
           "options": {
             "raw": {
               "language": "json"


### PR DESCRIPTION
**説明**
・勉強記録によってコインが加算されるようにしました。(そのレートは.envを参照します)
・ストアにある建物のうち購入していない建物一覧を取得するAPI
・建物購入API

また、これらに対するCIを追加しました。

**確認方法**
.envが更新されているので気をつけてください。
```
docker compose up --build -d
```
で起動したのち、postmanにて以下を順に実行してください。
1.右上の「環境なし」を「matcha」に変更してください。
2.「ユーザー登録」「ログイン」を送信してください。
3.「管理者ログイン」を送信してください。
4.「建物をストアに追加(管理者)」をデフォルトで入っているデータで送信してください。
5.「所有している建物一覧」を送信してID1の建物を所有していることを確認してください。
6.「ストアにある建物一覧」を送信してID2,3の建物がストアにあることを確認してください。(4で追加したもの)
7.「建物購入」をデフォルトのデータで送信してID2の建物を購入できるか試す。この時点ではユーザーがまだコインを持っていないのでエラーになります。
8.「作業追加」と「作業ログ記録」を送信してください。これによりコインが獲得できます。
9.改めて7を実行してください。成功することを確認してください。

**今後の展望**
・毎日決まった時間にストアを更新できるような関数
・サーバー用とユーザー用でわかりやすいエラー分を作成する