### PR TITLE
[Fix] フロントでの表示の大きさを画面の大きさに対して設定

### DIFF
--- a/frontend-nodejs/src/app/buildings/page.tsx
+++ b/frontend-nodejs/src/app/buildings/page.tsx
@@ -454,42 +454,31 @@ export default function BuildingsPage() {
   };
 
   return (
-    <div
-      className="min-h-screen p-4 relative overflow-x-hidden"
-      style={{
-        backgroundImage: "linear-gradient(to bottom, #f0f4f8, #d1e3dd)",
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundAttachment: "fixed",
-      }}
-    >
-      {/* Decorative elements - 装飾要素をシンプルにするために削除 */}
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-amber-50 flex flex-col items-center justify-center px-2 sm:px-4 md:px-8 lg:px-12 xl:px-20 py-6 sm:py-10">
+      <header className="w-full max-w-5xl flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-8 px-2 sm:px-6 py-4">
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2 text-amber-800 font-medium hover:bg-amber-100 transition-all duration-300"
+          onClick={() => router.push("/profile")}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          プロフィールに戻る
+        </Button>
+        <h1 className="text-2xl font-bold text-center text-amber-800 flex items-center gap-2">
+          <TreeDeciduous className="h-6 w-6 text-green-600" />
+          マイタウン
+        </h1>
+        <Button
+          variant="outline"
+          className="flex items-center gap-2 bg-amber-100 border-2 border-amber-300 text-amber-800 hover:bg-amber-200"
+          onClick={handleRefresh}
+        >
+          <Loader2 className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+          更新
+        </Button>
+      </header>
 
-      <div className="container mx-auto max-w-6xl relative z-10">
-        {/* Header with navigation back to profile */}
-        <div className="flex items-center justify-between mb-6 bg-amber-50 p-4 rounded-xl border-4 border-amber-200 shadow-md">
-          <Button
-            variant="ghost"
-            className="flex items-center gap-2 text-amber-800 font-medium hover:bg-amber-100 transition-all duration-300"
-            onClick={() => router.push("/profile")}
-          >
-            <ArrowLeft className="h-4 w-4" />
-            プロフィールに戻る
-          </Button>
-          <h1 className="text-2xl font-bold text-center text-amber-800 flex items-center gap-2">
-            <TreeDeciduous className="h-6 w-6 text-green-600" />
-            マイタウン
-          </h1>
-          <Button
-            variant="outline"
-            className="flex items-center gap-2 bg-amber-100 border-2 border-amber-300 text-amber-800 hover:bg-amber-200"
-            onClick={handleRefresh}
-          >
-            <Loader2 className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
-            更新
-          </Button>
-        </div>
-
+      <main className="w-full max-w-5xl mx-auto flex flex-col gap-5 sm:gap-8 md:gap-12 px-2 sm:px-6">
         {/* Error message */}
         {isError && (
           <div className="bg-red-50 border-4 border-red-200 text-red-700 p-4 rounded-xl mb-6 shadow-md">
@@ -769,7 +758,7 @@ export default function BuildingsPage() {
             )}
           </>
         )}
-      </div>
+      </main>
 
       {/* 削除確認ダイアログ */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/frontend-nodejs/src/app/myhouse/components/TaskManagement.tsx
+++ b/frontend-nodejs/src/app/myhouse/components/TaskManagement.tsx
@@ -193,9 +193,9 @@ export const TaskManagement = () => {
   const handleRemoveIcon = () => setNewTaskIcon(null);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 mb-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-2 sm:p-4 mb-6 w-full max-w-2xl mx-auto">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">タスク管理</h2>
+        <h2 className="text-lg sm:text-xl font-bold">タスク管理</h2>
         <div className="flex space-x-2">
           <Button
             onClick={() => setShowAddTask(!showAddTask)}
@@ -216,7 +216,7 @@ export const TaskManagement = () => {
             exit={{ height: 0, opacity: 0 }}
             className="overflow-hidden mb-6"
           >
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-2 sm:p-4">
               <h3 className="font-medium mb-2">新しいタスク</h3>
               <div className="space-y-3">
                 <div>
@@ -233,6 +233,7 @@ export const TaskManagement = () => {
                       setNewTask({ ...newTask, title: e.target.value })
                     }
                     placeholder="例: レポート作成"
+                    className="text-sm sm:text-base"
                   />
                 </div>
                 <div>
@@ -249,6 +250,7 @@ export const TaskManagement = () => {
                     onChange={(e) =>
                       setNewTask({ ...newTask, deadline: e.target.value })
                     }
+                    className="text-sm sm:text-base"
                   />
                 </div>
                 <div>
@@ -265,6 +267,7 @@ export const TaskManagement = () => {
                     onChange={(e) =>
                       setNewTask({ ...newTask, color: e.target.value })
                     }
+                    className="h-8 w-16"
                   />
                 </div>
                 <div>
@@ -281,7 +284,7 @@ export const TaskManagement = () => {
                       setNewTask({ ...newTask, memo: e.target.value })
                     }
                     className={
-                      `w-full border rounded p-2 text-sm ` +
+                      `w-full border rounded p-2 text-sm sm:text-base ` +
                       (typeof window !== "undefined" &&
                       document.documentElement.classList.contains("dark")
                         ? "bg-amber-900/60 border-yellow-700 text-yellow-100 placeholder-yellow-200"
@@ -296,7 +299,7 @@ export const TaskManagement = () => {
                     アイコン画像（任意）
                   </label>
                   <div
-                    className={`flex items-center gap-3 border-2 rounded p-2 transition-colors ${isDragging ? "border-amber-400 bg-amber-50" : "border-gray-200"}`}
+                    className={`flex flex-col sm:flex-row items-center gap-3 border-2 rounded p-2 transition-colors ${isDragging ? "border-amber-400 bg-amber-50" : "border-gray-200"}`}
                     onDragOver={handleDragOver}
                     onDragLeave={handleDragLeave}
                     onDrop={handleDrop}
@@ -338,11 +341,11 @@ export const TaskManagement = () => {
                     )}
                   </div>
                 </div>
-                <div className="flex justify-end">
+                <div className="flex flex-col sm:flex-row justify-end gap-2">
                   <Button
                     variant="outline"
                     size="sm"
-                    className="mr-2"
+                    className="w-full sm:w-auto"
                     onClick={() => setShowAddTask(false)}
                   >
                     キャンセル
@@ -350,7 +353,7 @@ export const TaskManagement = () => {
                   <Button
                     onClick={handleTaskSubmit}
                     size="sm"
-                    className="bg-amber-500 hover:bg-amber-600"
+                    className="w-full sm:w-auto bg-amber-500 hover:bg-amber-600"
                   >
                     {"保存"}
                     {!showAddTask && <Save className="h-4 w-4 ml-1" />}
@@ -362,7 +365,7 @@ export const TaskManagement = () => {
         )}
       </AnimatePresence>
 
-      <div className="space-y-4 max-h-80 overflow-y-auto pr-1">
+      <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
         {uncompletedTasks.length === 0 ? (
           <p className="text-center text-gray-500 dark:text-gray-400 py-4">
             タスクはありません
@@ -499,9 +502,9 @@ const TaskItem = ({
     }
   }
   return (
-    <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-650 transition-all">
-      <div className="flex-1 min-w-0">
-        <div className="flex items-start">
+    <div className="flex flex-col sm:flex-row items-center justify-between bg-gray-50 dark:bg-gray-700 p-2 sm:p-3 rounded-lg border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-650 transition-all">
+      <div className="flex-1 min-w-0 w-full">
+        <div className="flex items-start flex-col sm:flex-row">
           {task.iconImageURL && (
             <Image
               src={task.iconImageURL}
@@ -518,10 +521,11 @@ const TaskItem = ({
               }}
             />
           )}
-          <div>
-            <h4 className="font-medium text-gray-800 dark:text-gray-200 truncate">
+          <div className="w-full">
+            <h4 className="font-medium text-gray-800 dark:text-gray-200 truncate text-base sm:text-lg">
               {task.title}
             </h4>
+
             {typeof task.memo === "string" && task.memo.trim() !== "" && (
               <div
                 className={
@@ -536,7 +540,7 @@ const TaskItem = ({
                 {task.memo}
               </div>
             )}
-            <div className="flex flex-wrap gap-2 mt-1">
+            <div className="flex flex-wrap gap-2 mt-1 text-xs sm:text-sm">
               <span
                 className={`text-xs px-2 py-0.5 rounded flex items-center ${
                   !task.deadline
@@ -587,17 +591,17 @@ const TaskItem = ({
           </div>
         </div>
       </div>
-      <div className="flex items-center ml-4 gap-2">
+      <div className="flex items-center ml-0 sm:ml-4 gap-2 w-full sm:w-auto mt-2 sm:mt-0">
         <button
           onClick={() => onRecord(task.id)}
-          className="px-3 py-2 rounded-full bg-green-200 hover:bg-green-300 text-green-800 font-bold flex items-center gap-1 shadow transition-transform hover:scale-105"
+          className="px-3 py-2 rounded-full bg-green-200 hover:bg-green-300 text-green-800 font-bold flex items-center gap-1 shadow transition-transform hover:scale-105 w-full sm:w-auto"
         >
           <BookOpen className="w-4 h-4" />
           記録する
         </button>
         <button
           onClick={() => onComplete(task.id)}
-          className="relative group"
+          className="relative group w-full sm:w-auto"
           aria-label="タスク完了"
         >
           <div className="w-10 h-10 rounded-full flex items-center justify-center bg-amber-100 hover:bg-amber-200 dark:bg-amber-800 dark:hover:bg-amber-700 border-2 border-amber-300 dark:border-amber-600 transition-all transform group-hover:scale-110">
@@ -632,7 +636,7 @@ const TaskItem = ({
         </button>
         <button
           onClick={() => onDelete(task.id)}
-          className="ml-2 flex items-center gap-1 bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-full transition-colors shadow-sm"
+          className="ml-0 sm:ml-2 flex items-center gap-1 bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-full transition-colors shadow-sm w-full sm:w-auto"
           aria-label="タスク削除"
         >
           <Trash2 className="h-4 w-4" />

--- a/frontend-nodejs/src/app/myhouse/page.tsx
+++ b/frontend-nodejs/src/app/myhouse/page.tsx
@@ -20,10 +20,20 @@ import {
   CheckCircle,
   FileText,
   AlertTriangle,
+  LogOut,
 } from "lucide-react";
 import { ChatPanel } from "./components/ChatPanel";
 import { Message } from "./types";
 import { formatTime, formatDeadline } from "./lib/timeUtils";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useRouter } from "next/navigation";
 
 // APIから取得するタスクの型定義
 interface ApiTask {
@@ -475,6 +485,15 @@ export default function MyHousePage() {
     );
   };
 
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+  const router = useRouter();
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    setShowLogoutDialog(false);
+    router.push("/settlement");
+  };
+
   return (
     <main className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100 dark:from-amber-900 dark:to-amber-800">
       <header className="bg-amber-800 text-amber-50 p-4 flex items-center justify-between z-50 sticky top-0 left-0 right-0 font-sans">
@@ -502,8 +521,50 @@ export default function MyHousePage() {
               {userStats.totalStudyHours}時間
             </span>
           </div>
+
+          {/* Logout Button */}
+          <button
+            onClick={() => setShowLogoutDialog(true)}
+            className="ml-4 flex items-center px-3 py-2 rounded-lg bg-amber-700 hover:bg-red-600 transition-colors text-white font-semibold shadow border border-amber-600 hover:border-red-700"
+            title="ログアウト"
+          >
+            <LogOut className="h-5 w-5 mr-1" />
+            myhouseログアウト
+          </button>
         </div>
       </header>
+
+      {/* Logout Confirmation Dialog */}
+      <Dialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
+        <DialogContent className="bg-white dark:bg-amber-900 border-amber-300 dark:border-amber-800">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-lg">
+              <LogOut className="h-6 w-6 text-red-600" />
+              ログアウト確認
+            </DialogTitle>
+            <DialogDescription className="text-base mt-2">
+              本当にログアウトしますか？
+              <br />
+              ログアウトするとマイハウスから退出し、精算ページに移動します。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex-row gap-3 mt-6 mb-2">
+            <button
+              onClick={() => setShowLogoutDialog(false)}
+              className="flex-1 py-3 px-5 rounded-lg text-base font-medium transition-colors bg-amber-100 hover:bg-amber-200 text-amber-800"
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={handleLogout}
+              className="flex-1 py-3 px-5 rounded-lg text-base font-medium transition-colors bg-red-600 hover:bg-red-700 text-white flex items-center justify-center"
+            >
+              <LogOut className="h-5 w-5 mr-2" />
+              ログアウト
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* タスク完了モーダル */}
       {showCompletionModal && completedTaskId && (

--- a/frontend-nodejs/src/app/myhouse/page.tsx
+++ b/frontend-nodejs/src/app/myhouse/page.tsx
@@ -545,7 +545,7 @@ export default function MyHousePage() {
             <DialogDescription className="text-base mt-2">
               本当にログアウトしますか？
               <br />
-              ログアウトするとマイハウスから退出し、精算ページに移動します。
+              ログアウトするとマイハウスから退出し、建物一覧ページに移動します。
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex-row gap-3 mt-6 mb-2">

--- a/frontend-nodejs/src/app/myhouse/page.tsx
+++ b/frontend-nodejs/src/app/myhouse/page.tsx
@@ -53,6 +53,27 @@ interface TabInfo {
   icon: LucideIcon;
 }
 
+// Cardコンポーネントをファイル内で定義
+function Card({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="bg-gradient-to-br from-amber-500 to-amber-600 rounded-xl p-4 text-white flex items-center space-x-3 shadow-md">
+      <div className="text-white">{icon}</div>
+      <div>
+        <div className="text-sm opacity-80">{label}</div>
+        <div className="text-xl font-bold">{value}</div>
+      </div>
+    </div>
+  );
+}
+
 export default function MyHousePage() {
   const { isDarkMode } = useTheme();
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -416,15 +437,6 @@ export default function MyHousePage() {
     }, 3000);
   };
 
-  // handleTaskAdd 関数を追加
-  const handleTaskAdd = (task: Task) => {
-    setTasks((prev) => [...prev, task]);
-    // タスクが追加されたらAPIタスクも再取得
-    setTimeout(() => {
-      fetchApiTasks();
-    }, 500);
-  };
-
   // 完了済みタスクを維持するための処理を追加
   useEffect(() => {
     // ローカルストレージから完了済みタスクIDのリストを取得
@@ -495,8 +507,9 @@ export default function MyHousePage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100 dark:from-amber-900 dark:to-amber-800">
-      <header className="bg-amber-800 text-amber-50 p-4 flex items-center justify-between z-50 sticky top-0 left-0 right-0 font-sans">
+    <div className="min-h-screen bg-gradient-to-br from-emerald-100 to-amber-50 flex flex-col items-center justify-center px-2 sm:px-3 md:px-6 lg:px-10 xl:px-16 py-6 sm:py-10">
+      {/* 固定ヘッダー */}
+      <header className="sticky top-0 left-0 right-0 z-50 w-full max-w-7xl flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-8 px-2 sm:px-6 py-4 bg-gradient-to-br from-emerald-100 to-amber-50">
         <div className="flex items-center">
           <Home className="h-7 w-7 mr-2" />
           <h1 className="text-xl font-bold tracking-wide">
@@ -506,7 +519,6 @@ export default function MyHousePage() {
             Lv.{userStats.level}
           </span>
         </div>
-
         <div className="flex items-center space-x-6">
           <div className="flex items-center">
             <Calendar className="h-6 w-6 mr-2" />
@@ -514,14 +526,12 @@ export default function MyHousePage() {
               {userStats.dayStreak}日連続
             </span>
           </div>
-
           <div className="flex items-center">
             <BookOpen className="h-6 w-6 mr-2" />
             <span className="text-lg font-medium">
               {userStats.totalStudyHours}時間
             </span>
           </div>
-
           {/* Logout Button */}
           <button
             onClick={() => setShowLogoutDialog(true)}
@@ -533,6 +543,295 @@ export default function MyHousePage() {
           </button>
         </div>
       </header>
+
+      {/* タブナビゲーション（モバイル下部/PC左サイド） */}
+      <div className="w-full max-w-7xl">
+        {/* モバイル向けのタブナビゲーション */}
+        <div className="lg:hidden flex border-b mb-6 overflow-x-auto bg-white/80 rounded-t-xl">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                "flex items-center gap-2 px-4 py-3 whitespace-nowrap",
+                activeTab === tab.id
+                  ? isDarkMode
+                    ? "border-b-2 border-amber-500 text-amber-100 font-medium"
+                    : "border-b-2 border-amber-500 text-amber-800 font-medium"
+                  : isDarkMode
+                    ? "text-amber-300"
+                    : "text-amber-600",
+              )}
+            >
+              <tab.icon className="h-5 w-5" />
+              <span>{tab.label}</span>
+            </button>
+          ))}
+        </div>
+        <div className="grid grid-cols-10 gap-6">
+          {/* サイドバーナビゲーション（デスクトップ） */}
+          <div className="hidden lg:block lg:col-span-2">
+            <div className="bg-white dark:bg-amber-800/90 rounded-lg shadow-md border border-amber-200 dark:border-amber-700 overflow-hidden sticky top-24">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={cn(
+                    "w-full flex items-center gap-3 px-4 py-4 text-left transition-colors",
+                    activeTab === tab.id
+                      ? isDarkMode
+                        ? "bg-amber-700/50 text-amber-50 font-medium border-l-4 border-amber-500"
+                        : "bg-amber-100 text-amber-800 font-medium border-l-4 border-amber-500"
+                      : isDarkMode
+                        ? "text-amber-200 hover:bg-amber-800/50"
+                        : "text-amber-700 hover:bg-amber-50",
+                  )}
+                >
+                  <tab.icon className="h-5 w-5" />
+                  <span>{tab.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          {/* メインコンテンツエリア */}
+          <div className="lg:col-span-8">
+            <main className="w-full flex flex-col gap-6 sm:gap-10 md:gap-14 lg:gap-16 px-2 sm:px-6">
+              {/* 学習データサマリー - 常に表示 */}
+              <StudyDataSummary />
+
+              {/* 学習ステータス */}
+              <div className="mb-8 p-4 bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-md">
+                <div className="flex items-center mb-3">
+                  <div className="w-8 h-8 bg-[#8cc750] rounded-full flex items-center justify-center border-2 border-[#7ab145] shadow-sm">
+                    <Clock className="h-5 w-5 text-white" />
+                  </div>
+                  <h3 className="ml-2 text-lg font-bold text-[#7b6c5d]">
+                    学習ステータス
+                  </h3>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="bg-white p-3 rounded-lg border border-[#e4cbac]">
+                    <div className="text-xs text-[#9b8e7e] mb-1">
+                      累計学習時間
+                    </div>
+                    <div className="text-xl font-bold text-[#7b6c5d]">
+                      {formatTime(
+                        tasks.reduce((sum, t) => sum + (t.timeSpent || 0), 0),
+                      )}
+                    </div>
+                  </div>
+                  <div className="bg-white p-3 rounded-lg border border-[#e4cbac]">
+                    <div className="text-xs text-[#9b8e7e] mb-1">
+                      今日の学習時間
+                    </div>
+                    <div className="text-xl font-bold text-[#7b6c5d]">
+                      {formatTime(
+                        tasks.reduce(
+                          (sum, task) => sum + (task.timeSpent || 0),
+                          0,
+                        ),
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* タブコンテンツ */}
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={activeTab}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 20 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {activeTab === "tasks" && (
+                    <>
+                      <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
+                        <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
+                          タスク管理
+                        </h3>
+                        <TaskManagement />
+                      </div>
+                    </>
+                  )}
+
+                  {activeTab === "completed" && (
+                    <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
+                      <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
+                        完了したタスク
+                      </h3>
+
+                      {/* 完了タスク一覧 */}
+                      <div className="space-y-4">
+                        {tasks.filter((task) => task.completed).length === 0 ? (
+                          <div className="text-center py-8">
+                            <FileText className="h-12 w-12 mx-auto text-amber-500 mb-2" />
+                            <p className="text-lg text-amber-800 dark:text-amber-200">
+                              完了したタスクはありません
+                            </p>
+                            <p className="text-sm text-amber-600 dark:text-amber-300">
+                              タスクを完了すると、ここに表示されます
+                            </p>
+                          </div>
+                        ) : (
+                          <>
+                            <div className="mb-4 bg-green-100 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4">
+                              <div className="flex items-center gap-2 text-green-800 dark:text-green-300 mb-2">
+                                <CheckCircle className="h-5 w-5" />
+                                <h4 className="font-medium">完了したタスク</h4>
+                              </div>
+                              <p className="text-sm text-green-700 dark:text-green-400">
+                                おめでとうございます！
+                                {tasks.filter((task) => task.completed).length}
+                                件のタスクを完了しました。
+                              </p>
+                            </div>
+
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                              {tasks
+                                .filter((task) => task.completed)
+                                .map((task) => (
+                                  <div
+                                    key={task.id}
+                                    className="bg-amber-50 dark:bg-amber-800/50 p-4 rounded-lg border border-amber-200 dark:border-amber-700"
+                                  >
+                                    <div className="flex items-start justify-between">
+                                      <div>
+                                        <h5 className="font-medium line-through text-amber-700 dark:text-amber-300">
+                                          {task.title}
+                                        </h5>
+                                        {task.completedDate && (
+                                          <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                                            完了日時:{" "}
+                                            {task.completedDate.toLocaleString()}
+                                          </p>
+                                        )}
+                                      </div>
+                                      <div className="bg-green-600 text-white text-xs px-2 py-1 rounded">
+                                        完了済み
+                                      </div>
+                                    </div>
+
+                                    <div className="mt-2 text-sm text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                                      <Clock className="h-4 w-4" />
+                                      <span>
+                                        学習時間:{" "}
+                                        {formatTime(task.timeSpent || 0)}
+                                      </span>
+                                    </div>
+
+                                    <button
+                                      onClick={() =>
+                                        handleTaskComplete(task.id)
+                                      }
+                                      className="mt-3 text-amber-700 dark:text-amber-300 text-sm underline flex items-center gap-1"
+                                    >
+                                      <span>未完了に戻す</span>
+                                    </button>
+                                  </div>
+                                ))}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {activeTab === "chat" && (
+                    <div
+                      className="bg-white dark:bg-amber-800/90 rounded-lg overflow-hidden shadow-md border border-amber-200 dark:border-amber-700"
+                      style={{ height: "600px" }}
+                    >
+                      <ChatPanel
+                        messages={messages}
+                        setMessages={setMessages}
+                        isDarkMode={isDarkMode}
+                      />
+                    </div>
+                  )}
+
+                  {activeTab === "stats" && (
+                    <>
+                      {/* 学習ステータス */}
+                      <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700 mb-6">
+                        <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
+                          学習統計
+                        </h3>
+                        <StudyTimeChart tasks={tasks} isDarkMode={isDarkMode} />
+                      </div>
+
+                      {/* タスク別分析 */}
+                      <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
+                        <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
+                          タスク別分析
+                        </h3>
+                        <div className="space-y-4">
+                          {tasks.length === 0 ? (
+                            <div className="text-center py-8">
+                              <AlertTriangle className="h-12 w-12 mx-auto text-amber-500 mb-2" />
+                              <p className="text-lg text-amber-800 dark:text-amber-200">
+                                タスクがありません
+                              </p>
+                              <p className="text-sm text-amber-600 dark:text-amber-300">
+                                タスクを追加すると、ここに分析データが表示されます
+                              </p>
+                            </div>
+                          ) : (
+                            tasks.map((task) => (
+                              <div
+                                key={task.id}
+                                className="p-4 border border-amber-200 dark:border-amber-700 rounded-lg"
+                              >
+                                <div className="flex justify-between items-start mb-2">
+                                  <div>
+                                    <h4 className="font-bold">{task.title}</h4>
+                                    <p className="text-sm text-amber-700 dark:text-amber-300">
+                                      {task.subject}
+                                    </p>
+                                  </div>
+                                  <div className="text-right">
+                                    <div className="font-medium">
+                                      {formatTime(task.timeSpent || 0)}
+                                    </div>
+                                    {task.deadline && (
+                                      <div
+                                        className={cn(
+                                          "text-xs",
+                                          new Date() > task.deadline
+                                            ? "text-red-500"
+                                            : "text-amber-600 dark:text-amber-300",
+                                        )}
+                                      >
+                                        {formatDeadline(task.deadline)}
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                                <div className="w-full bg-amber-100 dark:bg-amber-700/30 h-2 rounded-full overflow-hidden">
+                                  <div
+                                    className="bg-amber-500 h-full rounded-full"
+                                    style={{
+                                      width: `${Math.min(
+                                        100,
+                                        (task.timeSpent || 0) / 60,
+                                      )}%`,
+                                    }}
+                                  ></div>
+                                </div>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            </main>
+          </div>
+        </div>
+      </div>
 
       {/* Logout Confirmation Dialog */}
       <Dialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
@@ -596,317 +895,6 @@ export default function MyHousePage() {
           </div>
         </div>
       )}
-
-      <div className="container mx-auto px-4 py-8 max-w-6xl">
-        {/* モバイル向けのタブナビゲーション */}
-        <div className="lg:hidden flex border-b mb-6 overflow-x-auto">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={cn(
-                "flex items-center gap-2 px-4 py-3 whitespace-nowrap",
-                activeTab === tab.id
-                  ? isDarkMode
-                    ? "border-b-2 border-amber-500 text-amber-100 font-medium"
-                    : "border-b-2 border-amber-500 text-amber-800 font-medium"
-                  : isDarkMode
-                    ? "text-amber-300"
-                    : "text-amber-600",
-              )}
-            >
-              <tab.icon className="h-5 w-5" />
-              <span>{tab.label}</span>
-            </button>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-          {/* サイドバーナビゲーション（デスクトップ） */}
-          <div className="hidden lg:block lg:col-span-3">
-            <div className="bg-white dark:bg-amber-800/90 rounded-lg shadow-md border border-amber-200 dark:border-amber-700 overflow-hidden sticky top-24">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={cn(
-                    "w-full flex items-center gap-3 px-4 py-4 text-left transition-colors",
-                    activeTab === tab.id
-                      ? isDarkMode
-                        ? "bg-amber-700/50 text-amber-50 font-medium border-l-4 border-amber-500"
-                        : "bg-amber-100 text-amber-800 font-medium border-l-4 border-amber-500"
-                      : isDarkMode
-                        ? "text-amber-200 hover:bg-amber-800/50"
-                        : "text-amber-700 hover:bg-amber-50",
-                  )}
-                >
-                  <tab.icon className="h-5 w-5" />
-                  <span>{tab.label}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* メインコンテンツエリア */}
-          <div className="lg:col-span-9">
-            {/* 学習データサマリー - 常に表示 */}
-            <StudyDataSummary />
-
-            {/* 学習ステータス */}
-            <div className="mb-8 p-4 bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-md">
-              <div className="flex items-center mb-3">
-                <div className="w-8 h-8 bg-[#8cc750] rounded-full flex items-center justify-center border-2 border-[#7ab145] shadow-sm">
-                  <Clock className="h-5 w-5 text-white" />
-                </div>
-                <h3 className="ml-2 text-lg font-bold text-[#7b6c5d]">
-                  学習ステータス
-                </h3>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="bg-white p-3 rounded-lg border border-[#e4cbac]">
-                  <div className="text-xs text-[#9b8e7e] mb-1">
-                    累計学習時間
-                  </div>
-                  <div className="text-xl font-bold text-[#7b6c5d]">
-                    {formatTime(
-                      tasks.reduce((sum, t) => sum + (t.timeSpent || 0), 0),
-                    )}
-                  </div>
-                </div>
-                <div className="bg-white p-3 rounded-lg border border-[#e4cbac]">
-                  <div className="text-xs text-[#9b8e7e] mb-1">
-                    今日の学習時間
-                  </div>
-                  <div className="text-xl font-bold text-[#7b6c5d]">
-                    {formatTime(
-                      tasks.reduce(
-                        (sum, task) => sum + (task.timeSpent || 0),
-                        0,
-                      ),
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* タブコンテンツ */}
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={activeTab}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 20 }}
-                transition={{ duration: 0.3 }}
-              >
-                {activeTab === "tasks" && (
-                  <>
-                    <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
-                      <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
-                        タスク管理
-                      </h3>
-                      <TaskManagement
-                        tasks={tasks}
-                        onTaskComplete={handleTaskComplete}
-                        onTaskAdd={handleTaskAdd}
-                      />
-                    </div>
-                  </>
-                )}
-
-                {activeTab === "completed" && (
-                  <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
-                    <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
-                      完了したタスク
-                    </h3>
-
-                    {/* 完了タスク一覧 */}
-                    <div className="space-y-4">
-                      {tasks.filter((task) => task.completed).length === 0 ? (
-                        <div className="text-center py-8">
-                          <FileText className="h-12 w-12 mx-auto text-amber-500 mb-2" />
-                          <p className="text-lg text-amber-800 dark:text-amber-200">
-                            完了したタスクはありません
-                          </p>
-                          <p className="text-sm text-amber-600 dark:text-amber-300">
-                            タスクを完了すると、ここに表示されます
-                          </p>
-                        </div>
-                      ) : (
-                        <>
-                          <div className="mb-4 bg-green-100 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4">
-                            <div className="flex items-center gap-2 text-green-800 dark:text-green-300 mb-2">
-                              <CheckCircle className="h-5 w-5" />
-                              <h4 className="font-medium">完了したタスク</h4>
-                            </div>
-                            <p className="text-sm text-green-700 dark:text-green-400">
-                              おめでとうございます！
-                              {tasks.filter((task) => task.completed).length}
-                              件のタスクを完了しました。
-                            </p>
-                          </div>
-
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            {tasks
-                              .filter((task) => task.completed)
-                              .map((task) => (
-                                <div
-                                  key={task.id}
-                                  className="bg-amber-50 dark:bg-amber-800/50 p-4 rounded-lg border border-amber-200 dark:border-amber-700"
-                                >
-                                  <div className="flex items-start justify-between">
-                                    <div>
-                                      <h5 className="font-medium line-through text-amber-700 dark:text-amber-300">
-                                        {task.title}
-                                      </h5>
-                                      {task.completedDate && (
-                                        <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                                          完了日時:{" "}
-                                          {task.completedDate.toLocaleString()}
-                                        </p>
-                                      )}
-                                    </div>
-                                    <div className="bg-green-600 text-white text-xs px-2 py-1 rounded">
-                                      完了済み
-                                    </div>
-                                  </div>
-
-                                  <div className="mt-2 text-sm text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                                    <Clock className="h-4 w-4" />
-                                    <span>
-                                      学習時間:{" "}
-                                      {formatTime(task.timeSpent || 0)}
-                                    </span>
-                                  </div>
-
-                                  <button
-                                    onClick={() => handleTaskComplete(task.id)}
-                                    className="mt-3 text-amber-700 dark:text-amber-300 text-sm underline flex items-center gap-1"
-                                  >
-                                    <span>未完了に戻す</span>
-                                  </button>
-                                </div>
-                              ))}
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {activeTab === "chat" && (
-                  <div
-                    className="bg-white dark:bg-amber-800/90 rounded-lg overflow-hidden shadow-md border border-amber-200 dark:border-amber-700"
-                    style={{ height: "600px" }}
-                  >
-                    <ChatPanel
-                      messages={messages}
-                      setMessages={setMessages}
-                      isDarkMode={isDarkMode}
-                    />
-                  </div>
-                )}
-
-                {activeTab === "stats" && (
-                  <>
-                    {/* 学習ステータス */}
-                    <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700 mb-6">
-                      <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
-                        学習統計
-                      </h3>
-                      <StudyTimeChart tasks={tasks} isDarkMode={isDarkMode} />
-                    </div>
-
-                    {/* タスク別分析 */}
-                    <div className="bg-white dark:bg-amber-800/90 rounded-lg p-6 shadow-md border border-amber-200 dark:border-amber-700">
-                      <h3 className="text-2xl font-bold mb-4 border-b pb-2 border-amber-200 dark:border-amber-700">
-                        タスク別分析
-                      </h3>
-                      <div className="space-y-4">
-                        {tasks.length === 0 ? (
-                          <div className="text-center py-8">
-                            <AlertTriangle className="h-12 w-12 mx-auto text-amber-500 mb-2" />
-                            <p className="text-lg text-amber-800 dark:text-amber-200">
-                              タスクがありません
-                            </p>
-                            <p className="text-sm text-amber-600 dark:text-amber-300">
-                              タスクを追加すると、ここに分析データが表示されます
-                            </p>
-                          </div>
-                        ) : (
-                          tasks.map((task) => (
-                            <div
-                              key={task.id}
-                              className="p-4 border border-amber-200 dark:border-amber-700 rounded-lg"
-                            >
-                              <div className="flex justify-between items-start mb-2">
-                                <div>
-                                  <h4 className="font-bold">{task.title}</h4>
-                                  <p className="text-sm text-amber-700 dark:text-amber-300">
-                                    {task.subject}
-                                  </p>
-                                </div>
-                                <div className="text-right">
-                                  <div className="font-medium">
-                                    {formatTime(task.timeSpent || 0)}
-                                  </div>
-                                  {task.deadline && (
-                                    <div
-                                      className={cn(
-                                        "text-xs",
-                                        new Date() > task.deadline
-                                          ? "text-red-500"
-                                          : "text-amber-600 dark:text-amber-300",
-                                      )}
-                                    >
-                                      {formatDeadline(task.deadline)}
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                              <div className="w-full bg-amber-100 dark:bg-amber-700/30 h-2 rounded-full overflow-hidden">
-                                <div
-                                  className="bg-amber-500 h-full rounded-full"
-                                  style={{
-                                    width: `${Math.min(
-                                      100,
-                                      (task.timeSpent || 0) / 60,
-                                    )}%`,
-                                  }}
-                                ></div>
-                              </div>
-                            </div>
-                          ))
-                        )}
-                      </div>
-                    </div>
-                  </>
-                )}
-              </motion.div>
-            </AnimatePresence>
-          </div>
-        </div>
-      </div>
-    </main>
-  );
-}
-
-// Card コンポーネント - 最初のコードのカード実装を利用
-function Card({
-  icon,
-  label,
-  value,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className="bg-gradient-to-br from-amber-500 to-amber-600 rounded-xl p-4 text-white flex items-center space-x-3 shadow-md">
-      <div className="text-white">{icon}</div>
-      <div>
-        <div className="text-sm opacity-80">{label}</div>
-        <div className="text-xl font-bold">{value}</div>
-      </div>
     </div>
   );
 }

--- a/frontend-nodejs/src/app/page.tsx
+++ b/frontend-nodejs/src/app/page.tsx
@@ -156,270 +156,52 @@ const DecorativeImage = ({
   );
 };
 
-// 複数の花を表示する汎用コンポーネント
-const FlowerLayer = ({
-  position = "top-right",
-  flowerImage = "/images/welcome-flower.webp",
-}: {
-  position: "top-right" | "bottom-left";
-  flowerImage?: string;
-}) => {
-  // 花の設定の型を定義
-  type FlowerConfig = {
-    containerClassName: string;
-    imageClassName?: string;
-    style?: React.CSSProperties;
-    width: number;
-    height: number;
-    alt: string;
-  };
-
-  // 位置設定の型を定義
-  type PositionConfig = {
-    flowers: FlowerConfig[];
-  };
-  // 位置に基づく設定を定義
-  const positionSettings: Record<string, PositionConfig> = {
-    "top-right": {
-      flowers: [
-        {
-          containerClassName:
-            "absolute top-0 right-0 w-[15%] max-w-[180px] z-30",
-          imageClassName: "w-full",
-          style: {
-            animation: "sway 4s ease-in-out infinite alternate",
-            transformOrigin: "center bottom",
-          },
-          width: 300,
-          height: 300,
-          alt: "花 (前面)",
-        },
-        {
-          containerClassName:
-            "absolute top-[2%] right-[5%] w-[13%] max-w-[160px] z-20",
-          imageClassName: "w-full opacity-90",
-          style: {
-            animation: "sway 5s ease-in-out 0.7s infinite alternate-reverse",
-            transformOrigin: "center bottom",
-          },
-          width: 280,
-          height: 280,
-          alt: "花 (中間)",
-        },
-        {
-          containerClassName:
-            "absolute top-[4%] right-[10%] w-[11%] max-w-[140px] z-10",
-          imageClassName: "w-full opacity-80",
-          style: {
-            animation: "sway 6s ease-in-out 1.4s infinite alternate",
-            transformOrigin: "center bottom",
-          },
-          width: 260,
-          height: 260,
-          alt: "花 (背面)",
-        },
-      ],
-    },
-    "bottom-left": {
-      flowers: [
-        {
-          containerClassName:
-            "absolute bottom-0 left-0 w-[15%] max-w-[180px] z-30",
-          imageClassName: "w-full",
-          style: {
-            animation: "sway 4.5s ease-in-out 0.2s infinite alternate-reverse",
-            transformOrigin: "center bottom",
-          },
-          width: 300,
-          height: 300,
-          alt: "花 (左下前面)",
-        },
-        {
-          containerClassName:
-            "absolute bottom-[2%] left-[5%] w-[13%] max-w-[160px] z-20",
-          imageClassName: "w-full opacity-90",
-          style: {
-            animation: "sway 5.2s ease-in-out 0.9s infinite alternate",
-            transformOrigin: "center bottom",
-          },
-          width: 280,
-          height: 280,
-          alt: "花 (左下中間)",
-        },
-        {
-          containerClassName:
-            "absolute bottom-[4%] left-[10%] w-[11%] max-w-[140px] z-10",
-          imageClassName: "w-full opacity-80",
-          style: {
-            animation: "sway 6.5s ease-in-out 1.6s infinite alternate-reverse",
-            transformOrigin: "center bottom",
-          },
-          width: 260,
-          height: 260,
-          alt: "花 (左下背面)",
-        },
-      ],
-    },
-  };
-
-  const flowers: FlowerConfig[] = positionSettings[position]?.flowers || [];
-
-  return (
-    <>
-      {flowers.map((flower: FlowerConfig, index: number) => (
-        <DecorativeImage
-          key={index}
-          src={flowerImage}
-          alt={flower.alt}
-          width={flower.width}
-          height={flower.height}
-          containerClassName={flower.containerClassName}
-          imageClassName={flower.imageClassName}
-          style={flower.style}
-        />
-      ))}
-    </>
-  );
-};
-
 // メインコンテンツコンポーネント
 const MainContent = () => {
-  // 装飾画像の設定を一元管理
-  const decorations = [
-    {
-      src: "/images/welcome-red-flower.webp",
-      alt: "赤い花",
-      width: 300,
-      height: 300,
-      containerClassName:
-        "absolute bottom-[5%] left-[5%] w-[12%] max-w-[180px] z-10",
-    },
-    {
-      src: "/images/welcome-hiyoko.webp",
-      alt: "ひよこ",
-      width: 160,
-      height: 160,
-      containerClassName:
-        "absolute bottom-0 right-[20%] w-[8%] max-w-[100px] z-10",
-    },
-    {
-      src: "/images/welcome-fox.webp",
-      alt: "狐",
-      width: 350,
-      height: 350,
-      containerClassName:
-        "absolute bottom-[8%] left-[15%] w-[14%] max-w-[200px] z-10",
-    },
-    {
-      src: "/images/welcome-flower&butterfly.webp",
-      alt: "花と蝶",
-      width: 250,
-      height: 250,
-      containerClassName:
-        "absolute bottom-0 right-0 w-[15%] max-w-[200px] z-10",
-    },
-    {
-      src: "/images/macha-neko2.png",
-      alt: "ロゴネコ",
-      width: 400,
-      height: 400,
-      containerClassName:
-        "absolute bottom-[10%] right-[25%] w-[18%] max-w-[280px] z-20",
-    },
-    {
-      src: "/images/welcome-butterfly.webp",
-      alt: "蝶が飛んでいるアニメーション",
-      width: 120,
-      height: 120,
-      containerClassName:
-        "absolute top-1/2 right-[8%] w-[10%] max-w-[100px] z-30 transform -translate-y-1/2",
-      imageClassName: "w-full",
-      style: {
-        animation: "float 3s ease-in-out infinite alternate",
-      },
-    },
-    {
-      src: "/images/welcome-bird.webp",
-      alt: "飛んでいる鳥のアニメーション",
-      width: 300,
-      height: 300,
-      containerClassName:
-        "absolute top-1/3 left-[10%] w-[12%] max-w-[180px] z-20 transform -translate-y-1/2",
-      imageClassName: "w-full",
-      style: {
-        animation: "float 3s ease-in-out infinite alternate",
-      },
-    },
-    {
-      src: "/images/welcome-emmyu.webp",
-      alt: "エミュー",
-      width: 200,
-      height: 200,
-      containerClassName:
-        "absolute bottom-[10%] right-[40%] w-[10%] max-w-[120px] z-5",
-      imageClassName: "w-full opacity-80",
-      style: {
-        animation: "float 3s ease-in-out infinite alternate",
-        filter: "blur(0.5px)",
-        transform: "scale(0.9)",
-      },
-    },
-  ];
-
   return (
-    <div className="relative min-h-screen w-full overflow-hidden">
-      {/* 背景画像 - 画面全体にフィット */}
-      <div className="fixed inset-0 w-full h-full z-0">
-        <div className="absolute inset-0 bg-gradient-to-br from-green-50 to-emerald-100" />
-        <Image
-          src="/images/Welcome-background.png"
-          alt="背景画像"
-          fill
-          className="object-cover opacity-90 pointer-events-none"
-          priority
-        />
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-emerald-100 to-amber-50 flex flex-col items-center justify-center px-2 sm:px-4 md:px-8 lg:px-16 py-6 sm:py-10">
+      {/* レターボックス */}
+      <LetterBox />
 
       {/* メインコンテンツ */}
-      <div className="relative min-h-screen w-full flex flex-col items-center justify-center px-2 sm:px-6 md:px-8 py-6 sm:py-10 z-10">
-        <LetterBox />
-
-        <div className="w-full max-w-lg mx-auto mb-4 sm:mb-6 md:mb-8">
-          <p className="text-gray-800 text-sm sm:text-base md:text-lg text-center">
-            ここにアプリの紹介文などを入れる
+      <main className="w-full max-w-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-5xl mx-auto flex flex-col gap-8 sm:gap-10 md:gap-14">
+        {/* ボタン群 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 md:gap-8">
+          <WoodenSignButton href="/profile" primary direction="left">
+            プロフィール
+          </WoodenSignButton>
+          <WoodenSignButton href="/myhouse" direction="right">
+            マイハウス
+          </WoodenSignButton>
+          <WoodenSignButton href="/buildings" direction="left">
+            建物一覧
+          </WoodenSignButton>
+          <WoodenSignButton href="/settlement" direction="right">
+            精算ページ
+          </WoodenSignButton>
+          <WoodenSignButton href="/login" direction="left">
+            ログイン
+          </WoodenSignButton>
+          <WoodenSignButton href="/register" direction="right">
+            新規登録
+          </WoodenSignButton>
+        </div>
+        {/* 装飾画像や説明文も同様にレスポンシブクラスを追加 */}
+        <div className="flex flex-col md:flex-row items-center justify-between gap-6 md:gap-10">
+          <DecorativeImage
+            src="/images/welcome-flower.webp"
+            alt="花"
+            width={200}
+            height={200}
+            containerClassName="w-32 h-32 sm:w-40 sm:h-40 md:w-52 md:h-52 lg:w-60 lg:h-60"
+          />
+          <p className="text-base sm:text-lg md:text-xl text-center md:text-left max-w-md">
+            ようこそ！Matchaへ。
             <br />
+            あなたの学びと成長を応援します。
           </p>
         </div>
-
-        <div className="w-full max-w-md mx-auto mb-8">
-          <div className="flex flex-col gap-10 ">
-            <WoodenSignButton href="/register" primary direction="left">
-              新規登録
-            </WoodenSignButton>
-            <WoodenSignButton href="/login" direction="right">
-              ログイン
-            </WoodenSignButton>
-          </div>
-        </div>
-
-        {/* 装飾画像群 - パーセンテージベースの位置で配置 */}
-        {decorations.map((decoration, index) => (
-          <DecorativeImage
-            key={index}
-            src={decoration.src}
-            alt={decoration.alt}
-            width={decoration.width}
-            height={decoration.height}
-            containerClassName={decoration.containerClassName}
-            imageClassName={decoration.imageClassName}
-            style={decoration.style}
-          />
-        ))}
-
-        {/* 重なり合う花の装飾 */}
-        <FlowerLayer position="top-right" />
-        <FlowerLayer position="bottom-left" />
-      </div>
+      </main>
     </div>
   );
 };

--- a/frontend-nodejs/src/app/page.tsx
+++ b/frontend-nodejs/src/app/page.tsx
@@ -18,7 +18,7 @@ const WoodenSignButton = ({
   direction?: "left" | "right";
 }) => {
   const baseClasses =
-    "relative px-5 py-4 font-bold text-lg transform transition-transform duration-300 w-32 sm:w-40 md:w-48 mx-auto flex items-center justify-center";
+    "relative px-4 py-3 sm:px-5 sm:py-4 font-bold text-base sm:text-lg transform transition-transform duration-300 w-full sm:w-40 md:w-48 mx-auto flex items-center justify-center";
   const directionClass =
     direction === "left"
       ? "rotate-[-5deg] hover:rotate-0"
@@ -49,7 +49,7 @@ const WoodenSignButton = ({
   };
 
   return (
-    <div className="relative w-32 sm:w-40 md:w-48 mx-auto">
+    <div className="relative w-full sm:w-40 md:w-48 mx-auto">
       {/* 影の要素 - 看板とサイズを合わせる */}
       <div
         className={`absolute w-full h-full top-[5px] left-[6px] rounded ${directionClass}`}
@@ -81,7 +81,7 @@ const WoodenSignButton = ({
 // LetterBox コンポーネント - PRIVYの文字を表示
 const LetterBox = () => {
   return (
-    <div className="flex justify-center w-full mb-8">
+    <div className="flex justify-center w-full mb-6 sm:mb-8">
       <div className="flex space-x-2 sm:space-x-3 md:space-x-4">
         {["P", "R", "I", "V", "Y"].map((letter, index) => {
           const isBlackText =
@@ -89,7 +89,7 @@ const LetterBox = () => {
           return (
             <div
               key={index}
-              className="inline-block border-2 border-emerald-600 rounded-lg p-2 sm:p-3 md:p-4 w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 flex items-center justify-center shadow-md hover:shadow-lg transform hover:scale-110 transition-all duration-300"
+              className="inline-block border-2 border-emerald-600 rounded-lg p-2 sm:p-3 md:p-4 w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 flex items-center justify-center shadow-md hover:shadow-lg transform hover:scale-110 transition-all duration-300 text-center"
               style={{
                 animation: `bounce 1s ease-in-out ${index * 0.7}s infinite alternate`,
                 backgroundColor: `rgba(16, 185, 129, ${(index + 1) * 0.05 + 0.1})`,
@@ -381,11 +381,11 @@ const MainContent = () => {
       </div>
 
       {/* メインコンテンツ */}
-      <div className="relative min-h-screen w-full flex flex-col items-center justify-center px-4 sm:px-6 md:px-8 py-10 z-10">
+      <div className="relative min-h-screen w-full flex flex-col items-center justify-center px-2 sm:px-6 md:px-8 py-6 sm:py-10 z-10">
         <LetterBox />
 
-        <div className="w-full max-w-lg mx-auto mb-6 md:mb-8">
-          <p className="text-gray-800 text-sm sm:text-base md:text-lg">
+        <div className="w-full max-w-lg mx-auto mb-4 sm:mb-6 md:mb-8">
+          <p className="text-gray-800 text-sm sm:text-base md:text-lg text-center">
             ここにアプリの紹介文などを入れる
             <br />
           </p>

--- a/frontend-nodejs/src/app/profile/edit/page.tsx
+++ b/frontend-nodejs/src/app/profile/edit/page.tsx
@@ -319,22 +319,22 @@ export default function ProfileEditPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100">
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <div className="flex items-center mb-8">
+      <div className="container mx-auto px-2 sm:px-4 md:px-8 py-4 sm:py-8 max-w-lg sm:max-w-2xl md:max-w-3xl lg:max-w-4xl">
+        <div className="flex items-center mb-6 sm:mb-8">
           <button
             onClick={handleBackClick}
-            className="mr-4 p-2 rounded-full bg-amber-200 hover:bg-amber-300 transition-colors"
+            className="mr-2 sm:mr-4 p-2 rounded-full bg-amber-200 hover:bg-amber-300 transition-colors"
           >
             <ArrowLeft size={24} className="text-amber-800" />
           </button>
-          <h1 className="text-2xl font-bold text-amber-900">
+          <h1 className="text-xl sm:text-2xl font-bold text-amber-900">
             プロフィール編集
           </h1>
         </div>
 
         {isLoading ? (
-          <div className="flex justify-center items-center h-64">
-            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-amber-500"></div>
+          <div className="flex justify-center items-center h-48 sm:h-64">
+            <div className="animate-spin rounded-full h-10 w-10 sm:h-12 sm:w-12 border-t-2 border-b-2 border-amber-500"></div>
           </div>
         ) : error && !profile ? (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
@@ -346,11 +346,11 @@ export default function ProfileEditPage() {
             onSubmit={handleSubmit}
             className="bg-white rounded-xl shadow-lg overflow-hidden"
           >
-            <div className="bg-gradient-to-r from-amber-500 to-amber-400 p-6 text-white">
-              <div className="flex flex-col md:flex-row items-center gap-6">
-                <div className="relative w-32 h-32">
+            <div className="bg-gradient-to-r from-amber-500 to-amber-400 p-4 sm:p-6 text-white">
+              <div className="flex flex-col md:flex-row items-center gap-4 sm:gap-6">
+                <div className="relative w-24 h-24 sm:w-32 sm:h-32">
                   <div
-                    className="w-32 h-32 rounded-full overflow-hidden border-4 border-white shadow-md bg-amber-100 relative cursor-not-allowed"
+                    className="w-24 h-24 sm:w-32 sm:h-32 rounded-full overflow-hidden border-4 border-white shadow-md bg-amber-100 relative cursor-not-allowed"
                     onClick={handleImageButtonClick}
                     title="画像のアップロード機能は現在準備中です"
                   >
@@ -364,12 +364,12 @@ export default function ProfileEditPage() {
                       />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center">
-                        <User size={64} className="text-amber-300" />
+                        <User className="text-amber-300 w-12 h-12 sm:w-16 sm:h-16" />
                       </div>
                     )}
                     <div className="absolute inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center opacity-0 hover:opacity-100 transition-opacity">
                       <Upload
-                        size={24}
+                        size={20}
                         className="text-white mb-1 opacity-50"
                       />
                       <span className="text-white text-xs text-center px-1">
@@ -386,7 +386,7 @@ export default function ProfileEditPage() {
                   />
                 </div>
 
-                <div className="text-center md:text-left flex-1">
+                <div className="text-center md:text-left flex-1 w-full">
                   <FormField label="表示名" htmlFor="displayName">
                     <input
                       id="displayName"
@@ -394,39 +394,41 @@ export default function ProfileEditPage() {
                       type="text"
                       value={formData.displayName}
                       onChange={handleInputChange}
-                      className="w-full px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 font-medium"
+                      className="w-full px-3 sm:px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 font-medium text-base sm:text-lg"
                       placeholder="表示名を入力"
                       maxLength={15}
                     />
-                    <div className="text-xs text-gray-500 mt-1 text-right">
+                    <div className="text-xs text-gray-200 mt-1 text-right">
                       {formData.displayName.length}/15
                     </div>
                     {formData.displayName.length >= 13 &&
                       formData.displayName.length < 15 && (
-                        <span className="text-amber-500 text-xs ml-2">
+                        <span className="text-amber-100 text-xs ml-2">
                           制限に近づいています
                         </span>
                       )}
                     {formData.displayName.length >= 15 && (
-                      <span className="text-red-500 text-xs ml-2">
+                      <span className="text-red-200 text-xs ml-2">
                         文字数制限に達しました
                       </span>
                     )}
                   </FormField>
-                  <p className="text-amber-100 mt-1">@{profile.Username}</p>
+                  <p className="text-amber-100 mt-1 break-all text-xs sm:text-sm">
+                    @{profile.Username}
+                  </p>
                 </div>
               </div>
             </div>
 
-            <div className="p-6 space-y-6">
+            <div className="p-4 sm:p-6 space-y-6">
               <div className="space-y-4">
-                <h3 className="text-xl font-semibold text-amber-800 border-b pb-2 border-amber-200">
+                <h3 className="text-lg sm:text-xl font-semibold text-amber-800 border-b pb-2 border-amber-200">
                   基本情報
                 </h3>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
                   <FormField label="メールアドレス" htmlFor="email">
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2 sm:gap-3">
                       <Mail className="text-amber-500" />
                       <input
                         id="email"
@@ -434,7 +436,7 @@ export default function ProfileEditPage() {
                         type="email"
                         value={formData.email}
                         onChange={handleInputChange}
-                        className="w-full px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-90 disabled:bg-amber-50 disabled:text-gray-700 disabled:font-medium"
+                        className="w-full px-3 sm:px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-90 disabled:bg-amber-50 disabled:text-gray-700 disabled:font-medium text-base"
                         placeholder="メールアドレスを入力"
                         disabled
                       />
@@ -442,7 +444,7 @@ export default function ProfileEditPage() {
                   </FormField>
 
                   <FormField label="街の名前" htmlFor="townName">
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2 sm:gap-3">
                       <MapPin className="text-amber-500" />
                       <input
                         id="townName"
@@ -450,7 +452,7 @@ export default function ProfileEditPage() {
                         type="text"
                         value={formData.townName}
                         onChange={handleInputChange}
-                        className="w-full px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                        className="w-full px-3 sm:px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 text-base"
                         placeholder="あなたの街の名前を入力"
                         maxLength={25}
                       />
@@ -474,7 +476,7 @@ export default function ProfileEditPage() {
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-xl font-semibold text-amber-800 border-b pb-2 border-amber-200">
+                <h3 className="text-lg sm:text-xl font-semibold text-amber-800 border-b pb-2 border-amber-200">
                   自己紹介
                 </h3>
                 <textarea
@@ -482,7 +484,7 @@ export default function ProfileEditPage() {
                   name="introduction"
                   value={formData.introduction}
                   onChange={handleInputChange}
-                  className="w-full px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[120px]"
+                  className="w-full px-3 sm:px-4 py-2 rounded-md border border-amber-200 text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-500 min-h-[100px] sm:min-h-[120px] text-base"
                   placeholder="自己紹介を入力してください"
                   maxLength={200}
                 />
@@ -522,12 +524,12 @@ export default function ProfileEditPage() {
                 </div>
               )}
 
-              <div className="flex justify-end mt-6">
+              <div className="flex flex-col sm:flex-row justify-end mt-6 gap-2 sm:gap-4">
                 <Button
                   type="button"
                   variant="secondary"
                   onClick={handleBackClick}
-                  className="mr-4"
+                  className="mb-2 sm:mb-0 sm:mr-4"
                 >
                   キャンセル
                 </Button>

--- a/frontend-nodejs/src/app/profile/page.tsx
+++ b/frontend-nodejs/src/app/profile/page.tsx
@@ -603,40 +603,40 @@ export default function ProfilePage() {
       </div>
 
       {isLoading ? (
-        <div className="flex flex-col justify-center items-center h-64">
-          <div className="animate-bounce mb-4">
-            <Trees className="h-12 w-12 text-[#8cc750]" />
+        <div className="flex flex-col justify-center items-center h-48 sm:h-64">
+          <div className="animate-bounce mb-3 sm:mb-4">
+            <Trees className="h-8 w-8 sm:h-12 sm:w-12 text-[#8cc750]" />
           </div>
-          <p className="text-lg text-[#7b6c5d] font-medium">
+          <p className="text-base sm:text-lg text-[#7b6c5d] font-medium">
             ロード中<span className="animate-pulse">...</span>
           </p>
         </div>
       ) : error ? (
-        <div className="p-5 bg-[#f8eddc] border-2 border-[#e4a067] rounded-2xl shadow-md mb-6">
-          <h3 className="text-lg font-medium text-[#e38b31] mb-2 flex items-center">
+        <div className="p-3 sm:p-5 bg-[#f8eddc] border-2 border-[#e4a067] rounded-2xl shadow-md mb-4 sm:mb-6">
+          <h3 className="text-base sm:text-lg font-medium text-[#e38b31] mb-2 flex items-center">
             <AlertTriangle className="h-5 w-5 mr-2" /> おっと！
           </h3>
           <p className="text-[#7b6c5d]">{error}</p>
-          <p className="text-[#9b8e7e] mt-3 text-sm">
+          <p className="text-[#9b8e7e] mt-2 sm:mt-3 text-xs sm:text-sm">
             またあとでためしてみるか、運営に相談してみよう！
           </p>
         </div>
       ) : (
         <div>
           {/* クエストカードグリッド */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-5">
             {questCards.map((quest, index) => (
               <div
                 key={index}
-                className={`group relative transform transition-all duration-300 ${activeCard === index ? "scale-105" : "hover:scale-102"}`}
+                className={`group relative transform transition-all duration-300 ${activeCard === index ? "scale-105" : "hover:scale-102"} w-full`}
                 onMouseEnter={() => setActiveCard(index)}
                 onMouseLeave={() => setActiveCard(null)}
               >
                 <Card
-                  className={`${quest.color} border-2 ${quest.borderColor} rounded-xl shadow-md overflow-hidden cursor-pointer`}
+                  className={`${quest.color} border-2 ${quest.borderColor} rounded-xl shadow-md overflow-hidden cursor-pointer w-full`}
                   onClick={quest.onClick}
                 >
-                  <CardHeader className="pb-2 relative">
+                  <CardHeader className="pb-2 relative px-2 sm:px-4">
                     <div className="absolute -top-0 -left-0 bg-white rounded-br-xl px-2 pt-1 pb-2 border-r-2 border-b-2 border-[#e4cbac]">
                       <span className="text-xl">{quest.emoji}</span>
                     </div>
@@ -650,7 +650,7 @@ export default function ProfilePage() {
                       {quest.description}
                     </CardDescription>
                   </CardHeader>
-                  <CardContent className="flex-1 min-h-[80px] pb-2">
+                  <CardContent className="flex-1 min-h-[60px] sm:min-h-[80px] pb-2">
                     <div className="flex justify-center items-center h-full">
                       <div
                         className={`${quest.iconBg} p-4 rounded-full border-2 ${quest.iconBorder} shadow-md flex items-center justify-center`}
@@ -660,14 +660,14 @@ export default function ProfilePage() {
                     </div>
                   </CardContent>
                   <CardFooter
-                    className={`border-t-2 border-[#e4cbac] pt-3 pb-3 bg-[#f8eddc]/60`}
+                    className={`border-t-2 border-[#e4cbac] pt-2 sm:pt-3 pb-2 sm:pb-3 bg-[#f8eddc]/60`}
                   >
-                    <div className="flex items-center w-full justify-between">
-                      <div className="text-xs font-medium text-[#9b8e7e] flex items-center">
+                    <div className="flex flex-col sm:flex-row items-center w-full justify-between gap-2 sm:gap-0">
+                      <div className="text-xs sm:text-sm font-medium text-[#9b8e7e] flex items-center">
                         <Music className="h-3 w-3 mr-1" /> ミッション No.
                         {index + 1}
                       </div>
-                      <div className="bg-[#f8eddc] py-1 px-3 rounded-full text-xs text-[#7b6c5d] font-medium border border-[#e4cbac] flex items-center">
+                      <div className="bg-[#f8eddc] py-1 px-2 sm:px-3 rounded-full text-xs sm:text-sm text-[#7b6c5d] font-medium border border-[#e4cbac] flex items-center">
                         <Star className="h-3 w-3 text-[#e38b31] mr-1" />
                         {quest.reward}
                       </div>
@@ -688,7 +688,7 @@ export default function ProfilePage() {
       {/* 運営への報告ボタン - メタ機能 */}
       {!isLoading && !error && (
         <>
-          <div className="mt-16 mb-6 flex items-center gap-3">
+          <div className="mt-10 sm:mt-16 mb-4 sm:mb-6 flex items-center gap-2 sm:gap-3">
             <div className="h-px bg-red-300 flex-grow"></div>
             <span className="text-sm font-medium text-red-600 bg-red-50 px-3 py-1 rounded-full border border-red-200">
               アプリサポート
@@ -697,37 +697,37 @@ export default function ProfilePage() {
           </div>
 
           <div className="flex justify-center">
-            <div className="relative transform hover:scale-105 transition-all duration-300">
+            <div className="relative transform hover:scale-105 transition-all duration-300 w-full max-w-md">
               <button
                 onClick={() => router.push("/reports/submit")}
-                className="group px-8 py-4 bg-gradient-to-r from-red-50 to-white text-gray-800 rounded-lg border-2 border-red-300 transition-all duration-300 flex items-center gap-4 shadow-lg"
+                className="group w-full px-4 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-red-50 to-white text-gray-800 rounded-lg border-2 border-red-300 transition-all duration-300 flex flex-col sm:flex-row items-center gap-2 sm:gap-4 shadow-lg"
                 style={{
                   fontFamily: "sans-serif",
                 }}
               >
-                <div className="bg-red-100 p-2.5 rounded-full border-2 border-red-300 shadow-inner">
+                <div className="bg-red-100 p-2 sm:p-2.5 rounded-full border-2 border-red-300 shadow-inner">
                   <AlertTriangle className="h-6 w-6 text-red-600" />
                 </div>
                 <div className="flex flex-col items-start">
-                  <span className="font-bold text-sm uppercase tracking-wider text-red-500">
+                  <span className="font-bold text-xs sm:text-sm uppercase tracking-wider text-red-500">
                     SUPPORT CENTER
                   </span>
-                  <span className="font-semibold text-lg">
+                  <span className="font-semibold text-base sm:text-lg">
                     運営へのレポート / お問い合わせ
                   </span>
                 </div>
-                <div className="absolute -right-1 top-1/2 transform -translate-y-1/2 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center animate-pulse">
+                <div className="absolute -right-1 top-1/2 transform -translate-y-1/2 w-6 h-6 sm:w-8 sm:h-8 bg-red-500 rounded-full flex items-center justify-center animate-pulse">
                   <span className="text-white font-bold">→</span>
                 </div>
               </button>
-              <div className="absolute -top-3 -right-3 w-7 h-7 bg-red-500 rounded-full flex items-center justify-center border-2 border-white shadow-md">
+              <div className="absolute -top-2 sm:-top-3 -right-2 sm:-right-3 w-5 h-5 sm:w-7 sm:h-7 bg-red-500 rounded-full flex items-center justify-center border-2 border-white shadow-md">
                 <span className="text-white text-xs font-bold">!</span>
               </div>
               <div className="absolute -bottom-1 left-0 right-0 h-1 bg-gradient-to-r from-red-400 to-red-600 rounded-full"></div>
             </div>
           </div>
 
-          <p className="text-center text-sm text-red-600 font-medium mt-3 mb-4">
+          <p className="text-center text-xs sm:text-sm text-red-600 font-medium mt-2 sm:mt-3 mb-2 sm:mb-4">
             アプリの問題報告やご意見・ご要望はこちらからお願いします
           </p>
         </>
@@ -735,9 +735,9 @@ export default function ProfilePage() {
 
       {/* タスクモーダル */}
       {showTasksModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-lg w-full max-w-2xl max-h-[90vh] overflow-hidden">
-            <div className="flex justify-between items-center border-b-2 border-[#e4cbac] p-4">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">
+          <div className="bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-lg w-full max-w-lg sm:max-w-2xl max-h-[90vh] overflow-hidden">
+            <div className="flex justify-between items-center border-b-2 border-[#e4cbac] p-2 sm:p-4">
               <h3 className="text-xl font-bold text-[#7b6c5d] flex items-center">
                 <FileText className="h-5 w-5 mr-2 text-purple-900" />
                 あなたのタスク一覧
@@ -750,14 +750,14 @@ export default function ProfilePage() {
               </button>
             </div>
 
-            <div className="p-4 overflow-y-auto max-h-[70vh]">
+            <div className="p-2 sm:p-4 overflow-y-auto max-h-[60vh] sm:max-h-[70vh]">
               {isLoadingTasks ? (
                 <div className="flex flex-col items-center justify-center py-12">
                   <Loader2 className="h-10 w-10 text-purple-600 animate-spin mb-4" />
                   <p className="text-[#7b6c5d]">タスクを読み込み中...</p>
                 </div>
               ) : tasksError ? (
-                <div className="bg-red-50 border-2 border-red-200 rounded-xl p-4 text-center">
+                <div className="bg-red-50 border-2 border-red-200 rounded-xl p-2 sm:p-4 text-center">
                   <AlertTriangle className="h-8 w-8 text-red-500 mx-auto mb-2" />
                   <p className="text-red-600 font-medium">{tasksError}</p>
                   <button
@@ -768,17 +768,17 @@ export default function ProfilePage() {
                   </button>
                 </div>
               ) : tasks.length === 0 ? (
-                <div className="text-center py-10 bg-purple-50 rounded-xl border-2 border-purple-100">
-                  <div className="w-16 h-16 mx-auto bg-purple-100 rounded-full flex items-center justify-center mb-4">
-                    <FileText className="h-8 w-8 text-purple-800" />
+                <div className="text-center py-6 sm:py-10 bg-purple-50 rounded-xl border-2 border-purple-100">
+                  <div className="w-12 h-12 sm:w-16 sm:h-16 mx-auto bg-purple-100 rounded-full flex items-center justify-center mb-3 sm:mb-4">
+                    <FileText className="h-6 w-6 sm:h-8 sm:w-8 text-purple-800" />
                   </div>
-                  <h4 className="text-lg font-medium text-purple-900 mb-2">
+                  <h4 className="text-base sm:text-lg font-medium text-purple-900 mb-1 sm:mb-2">
                     タスクがまだありません
                   </h4>
-                  <p className="text-purple-700 mb-2">
+                  <p className="text-purple-700 mb-1 sm:mb-2 text-xs sm:text-base">
                     新しいタスクを追加して、学習の進捗を管理しましょう！
                   </p>
-                  <p className="text-purple-600 text-sm mb-4">
+                  <p className="text-purple-600 text-xs sm:text-sm mb-2 sm:mb-4">
                     日々の学習や課題をタスクとして登録すると、進捗の把握や振り返りに役立ちます
                   </p>
                   <button
@@ -786,7 +786,7 @@ export default function ProfilePage() {
                       setShowTasksModal(false);
                       openAddTaskModal();
                     }}
-                    className="px-4 py-2 bg-purple-200 hover:bg-purple-300 transition-colors rounded-lg text-purple-800 border border-purple-300 inline-flex items-center shadow-sm"
+                    className="w-full sm:w-auto px-4 py-2 bg-purple-200 hover:bg-purple-300 transition-colors rounded-lg text-purple-800 border border-purple-300 inline-flex items-center shadow-sm justify-center"
                   >
                     <Plus className="h-4 w-4 mr-1" /> 最初のタスクを追加する
                   </button>

--- a/frontend-nodejs/src/app/profile/page.tsx
+++ b/frontend-nodejs/src/app/profile/page.tsx
@@ -79,38 +79,56 @@ export default function ProfilePage() {
       setIsLoadingTasks(true);
       setTasksError(null);
 
-      const token = localStorage.getItem("token");
-      if (!token) {
-        setTasksError("認証情報がありません");
-        return;
-      }
+      // const token = localStorage.getItem("token");
+      // if (!token) {
+      //   setTasksError("認証情報がありません");
+      //   return;
+      // }
 
-      // タイムスタンプを追加してキャッシュを回避
-      const timestamp = Date.now();
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/works/get?t=${timestamp}`,
+      // // タイムスタンプを追加してキャッシュを回避
+      // const timestamp = Date.now();
+      // const response = await fetch(
+      //   `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/works/get?t=${timestamp}`,
+      //   {
+      //     method: "GET",
+      //     headers: {
+      //       Authorization: `Bearer ${token}`,
+      //       "Content-Type": "application/json",
+      //     },
+      //     cache: "no-store",
+      //   },
+      // );
+
+      // if (!response.ok) {
+      //   if (response.status === 401) {
+      //     router.push("/login");
+      //     return;
+      //   }
+      //   throw new Error(`タスクの取得に失敗しました (${response.status})`);
+      // }
+
+      // const data = await response.json();
+      // const worksData = data.Works || data.works || [];
+
+      // ダミータスクデータ
+      const worksData = [
         {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          cache: "no-store",
+          ID: 1,
+          WorkName: "プログラミング学習",
+          IconImageURL: "",
+          notes: "Reactの勉強",
+          timeSpent: 3600,
+          deadline: "2024-07-10T23:59:00",
         },
-      );
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          router.push("/login");
-          return;
-        }
-        throw new Error(`タスクの取得に失敗しました (${response.status})`);
-      }
-
-      const data = await response.json();
-
-      // データの存在確認とフォーマット検証を柔軟に行う
-      const worksData = data.Works || data.works || [];
+        {
+          ID: 2,
+          WorkName: "英語単語暗記",
+          IconImageURL: "",
+          notes: "毎日10単語",
+          timeSpent: 1800,
+          deadline: "2024-07-12T23:59:00",
+        },
+      ];
 
       // 合計作業時間を計算
       let total = 0;
@@ -118,31 +136,20 @@ export default function ProfilePage() {
       const todayStart = new Date();
       todayStart.setHours(0, 0, 0, 0);
 
-      worksData.forEach((task: Task) => {
-        // ここで作業時間を加算（今はダミーデータ）
-        // 実際には、APIからtimeSpentを取得する必要があります
-        const taskTime = task.timeSpent || Math.floor(Math.random() * 3600); // ダミーデータとして0〜3600秒
+      worksData.forEach((task) => {
+        const taskTime = task.timeSpent || 0;
         total += taskTime;
-
-        // 今日の分のみを集計（実際のAPIデータでは日付チェックが必要）
         today += taskTime;
       });
 
       // タスクを期限が近い順にソート
       const sortedTasks = [...worksData].sort((a, b) => {
-        // 期限がないタスクは後ろに配置
         if (!a.deadline) return 1;
         if (!b.deadline) return -1;
-
-        // 日付文字列をDateオブジェクトに変換して比較
         const dateA = new Date(a.deadline);
         const dateB = new Date(b.deadline);
-
-        // 無効な日付の場合は後ろに配置
         if (isNaN(dateA.getTime())) return 1;
         if (isNaN(dateB.getTime())) return -1;
-
-        // 日付の比較（昇順）
         return dateA.getTime() - dateB.getTime();
       });
 
@@ -150,7 +157,6 @@ export default function ProfilePage() {
       setTodayTaskTime(today);
       setTasks(sortedTasks);
     } catch (error) {
-      console.error("タスク取得エラー:", error);
       setTasksError(
         error instanceof Error ? error.message : "不明なエラーが発生しました",
       );
@@ -379,57 +385,58 @@ export default function ProfilePage() {
   };
 
   useEffect(() => {
+    // fetchProfileもAPI部分をコメントアウトしダミーデータをセット
     const fetchProfile = async () => {
       try {
         setIsLoading(true);
-        const token = localStorage.getItem("token");
-
-        if (!token) {
-          setError("認証情報がありません");
-          setIsLoading(false);
-          return;
-        }
-
-        // APIエンドポイントを呼び出し
-        // タイムスタンプをクエリパラメータに追加してキャッシュを回避
-        const timestamp = Date.now();
-        const apiUrl = `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/profile/get?t=${timestamp}`;
-        const headers = {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        };
-
-        const response = await fetch(apiUrl, {
-          method: "GET",
-          headers: headers,
-          cache: "no-store",
+        // const token = localStorage.getItem("token");
+        // if (!token) {
+        //   setError("認証情報がありません");
+        //   setIsLoading(false);
+        //   return;
+        // }
+        // const timestamp = Date.now();
+        // const apiUrl = `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/profile/get?t=${timestamp}`;
+        // const headers = {
+        //   Authorization: `Bearer ${token}`,
+        //   "Content-Type": "application/json",
+        // };
+        // const response = await fetch(apiUrl, {
+        //   method: "GET",
+        //   headers: headers,
+        //   cache: "no-store",
+        // });
+        // if (!response.ok) {
+        //   if (response.status === 401) {
+        //     throw new Error("認証エラー");
+        //   }
+        //   throw new Error(
+        //     `プロフィールの取得に失敗しました (${response.status})`,
+        //   );
+        // }
+        // const data = await response.json();
+        // const userData = data.User || data.user || data;
+        // if (!userData || (typeof userData === "object" && Object.keys(userData).length === 0)) {
+        //   throw new Error("プロフィールデータが見つかりません");
+        // }
+        // setProfile(userData);
+        // setImageKey((prev) => prev + 1);
+        // ダミープロフィールデータ
+        setProfile({
+          ID: 1,
+          Username: "demo_user",
+          DisplayName: "むらびと",
+          Email: "demo@example.com",
+          TownName: "デモ村",
+          Introduction: "これはダミープロフィールです。",
+          IconImageURL: "",
+          CoinCount: 1234,
+          Tags: ["サンプル", "テスト"],
+          CreatedAt: new Date().toISOString(),
+          UpdatedAt: new Date().toISOString(),
         });
-
-        if (!response.ok) {
-          if (response.status === 401) {
-            throw new Error("認証エラー");
-          }
-          throw new Error(
-            `プロフィールの取得に失敗しました (${response.status})`,
-          );
-        }
-
-        const data = await response.json();
-
-        // データの存在確認とフォーマット検証を柔軟に行う
-        const userData = data.User || data.user || data;
-
-        if (
-          !userData ||
-          (typeof userData === "object" && Object.keys(userData).length === 0)
-        ) {
-          throw new Error("プロフィールデータが見つかりません");
-        }
-
-        setProfile(userData);
         setImageKey((prev) => prev + 1);
       } catch (error) {
-        console.error("プロフィール取得エラー:", error);
         setError(
           error instanceof Error ? error.message : "不明なエラーが発生しました",
         );
@@ -437,20 +444,15 @@ export default function ProfilePage() {
         setIsLoading(false);
       }
     };
-
     fetchProfile();
-    // プロフィールページを開いたときにタスク情報も取得
     fetchTasks();
-
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         fetchProfile();
-        fetchTasks(); // タブが表示されたときにタスク情報も更新
+        fetchTasks();
       }
     };
-
     document.addEventListener("visibilitychange", handleVisibilityChange);
-
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
@@ -529,21 +531,21 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#e8f3d8] p-6 text-[#6a6359]">
-      <div className="flex items-center mb-8">
+    <div className="min-h-screen bg-[#e8f3d8] p-3 sm:p-6 text-[#6a6359] flex flex-col items-center">
+      <div className="flex flex-col sm:flex-row items-center mb-8 w-full max-w-4xl mx-auto gap-4 sm:gap-8">
         <button
           onClick={handleBackClick}
-          className="p-2 mr-4 rounded-full bg-[#f8eddc] hover:bg-[#f3e6d0] transition-colors border-2 border-[#e4cbac] shadow-md"
+          className="p-2 mr-0 sm:mr-4 rounded-full bg-[#f8eddc] hover:bg-[#f3e6d0] transition-colors border-2 border-[#e4cbac] shadow-md self-start"
         >
           <ArrowLeft className="h-5 w-5 text-[#7b6c5d]" />
         </button>
-        <div className="relative">
-          <h1 className="text-3xl font-bold text-[#7b6c5d]">
+        <div className="relative flex-1 w-full">
+          <h1 className="text-2xl sm:text-3xl font-bold text-[#7b6c5d]">
             プロフィールボード
           </h1>
           <div className="absolute -bottom-1 left-0 right-4 h-[3px] bg-[#bbd894]"></div>
         </div>
-        <div className="ml-auto flex space-x-2">
+        <div className="ml-0 sm:ml-auto flex space-x-2">
           <div className="py-1 px-3 bg-[#f8eddc] rounded-xl border-2 border-[#e4cbac] flex items-center shadow-md">
             <Star className="h-4 w-4 text-[#e38b31] mr-2" />
             <span className="font-medium text-[#7b6c5d]">
@@ -560,9 +562,9 @@ export default function ProfilePage() {
       </div>
 
       {/* プレイヤー情報 */}
-      <div className="mb-8 p-4 bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-md">
-        <div className="flex items-center">
-          <div className="w-16 h-16 bg-[#8cc750] rounded-full flex items-center justify-center border-2 border-[#7ab145] shadow-md overflow-hidden relative">
+      <div className="mb-8 p-4 sm:p-6 bg-[#f8eddc] rounded-2xl border-2 border-[#e4cbac] shadow-md w-full max-w-2xl mx-auto">
+        <div className="flex flex-col sm:flex-row items-center">
+          <div className="w-20 h-20 sm:w-24 sm:h-24 bg-[#8cc750] rounded-full flex items-center justify-center border-2 border-[#7ab145] shadow-md overflow-hidden relative">
             {profile?.IconImageURL ? (
               <Image
                 src={profile.IconImageURL}
@@ -588,11 +590,11 @@ export default function ProfilePage() {
                 }}
               />
             ) : (
-              <PawPrint className="h-8 w-8 text-white" />
+              <PawPrint className="h-10 w-10 sm:h-12 sm:w-12 text-white" />
             )}
           </div>
-          <div className="ml-4">
-            <h2 className="text-2xl font-bold text-[#7b6c5d]">
+          <div className="ml-0 sm:ml-4 mt-4 sm:mt-0 text-center sm:text-left">
+            <h2 className="text-xl sm:text-2xl font-bold text-[#7b6c5d]">
               {profile?.DisplayName || profile?.Username || "むらびと"}
             </h2>
             <p className="text-[#9b8e7e]">
@@ -602,93 +604,96 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="flex flex-col justify-center items-center h-48 sm:h-64">
-          <div className="animate-bounce mb-3 sm:mb-4">
-            <Trees className="h-8 w-8 sm:h-12 sm:w-12 text-[#8cc750]" />
+      {/* ローディング・エラー・クエストカードグリッド */}
+      <div className="w-full max-w-4xl mx-auto">
+        {isLoading ? (
+          <div className="flex flex-col justify-center items-center h-48 sm:h-64">
+            <div className="animate-bounce mb-3 sm:mb-4">
+              <Trees className="h-8 w-8 sm:h-12 sm:w-12 text-[#8cc750]" />
+            </div>
+            <p className="text-base sm:text-lg text-[#7b6c5d] font-medium">
+              ロード中<span className="animate-pulse">...</span>
+            </p>
           </div>
-          <p className="text-base sm:text-lg text-[#7b6c5d] font-medium">
-            ロード中<span className="animate-pulse">...</span>
-          </p>
-        </div>
-      ) : error ? (
-        <div className="p-3 sm:p-5 bg-[#f8eddc] border-2 border-[#e4a067] rounded-2xl shadow-md mb-4 sm:mb-6">
-          <h3 className="text-base sm:text-lg font-medium text-[#e38b31] mb-2 flex items-center">
-            <AlertTriangle className="h-5 w-5 mr-2" /> おっと！
-          </h3>
-          <p className="text-[#7b6c5d]">{error}</p>
-          <p className="text-[#9b8e7e] mt-2 sm:mt-3 text-xs sm:text-sm">
-            またあとでためしてみるか、運営に相談してみよう！
-          </p>
-        </div>
-      ) : (
-        <div>
-          {/* クエストカードグリッド */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-5">
-            {questCards.map((quest, index) => (
-              <div
-                key={index}
-                className={`group relative transform transition-all duration-300 ${activeCard === index ? "scale-105" : "hover:scale-102"} w-full`}
-                onMouseEnter={() => setActiveCard(index)}
-                onMouseLeave={() => setActiveCard(null)}
-              >
-                <Card
-                  className={`${quest.color} border-2 ${quest.borderColor} rounded-xl shadow-md overflow-hidden cursor-pointer w-full`}
-                  onClick={quest.onClick}
+        ) : error ? (
+          <div className="p-3 sm:p-5 bg-[#f8eddc] border-2 border-[#e4a067] rounded-2xl shadow-md mb-4 sm:mb-6">
+            <h3 className="text-base sm:text-lg font-medium text-[#e38b31] mb-2 flex items-center">
+              <AlertTriangle className="h-5 w-5 mr-2" /> おっと！
+            </h3>
+            <p className="text-[#7b6c5d]">{error}</p>
+            <p className="text-[#9b8e7e] mt-2 sm:mt-3 text-xs sm:text-sm">
+              またあとでためしてみるか、運営に相談してみよう！
+            </p>
+          </div>
+        ) : (
+          <div>
+            {/* クエストカードグリッド */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-5">
+              {questCards.map((quest, index) => (
+                <div
+                  key={index}
+                  className={`group relative transform transition-all duration-300 ${activeCard === index ? "scale-105" : "hover:scale-102"} w-full`}
+                  onMouseEnter={() => setActiveCard(index)}
+                  onMouseLeave={() => setActiveCard(null)}
                 >
-                  <CardHeader className="pb-2 relative px-2 sm:px-4">
-                    <div className="absolute -top-0 -left-0 bg-white rounded-br-xl px-2 pt-1 pb-2 border-r-2 border-b-2 border-[#e4cbac]">
-                      <span className="text-xl">{quest.emoji}</span>
-                    </div>
-                    <div className="absolute top-1 right-2 bg-[#f8eddc] text-xs font-medium py-0.5 px-2 rounded-full border border-[#e4cbac]">
-                      {quest.difficulty}
-                    </div>
-                    <CardTitle className="text-lg font-bold text-[#7b6c5d] mt-5 ml-2">
-                      {quest.title}
-                    </CardTitle>
-                    <CardDescription className="text-[#9b8e7e] ml-2">
-                      {quest.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="flex-1 min-h-[60px] sm:min-h-[80px] pb-2">
-                    <div className="flex justify-center items-center h-full">
-                      <div
-                        className={`${quest.iconBg} p-4 rounded-full border-2 ${quest.iconBorder} shadow-md flex items-center justify-center`}
-                      >
-                        {quest.icon}
-                      </div>
-                    </div>
-                  </CardContent>
-                  <CardFooter
-                    className={`border-t-2 border-[#e4cbac] pt-2 sm:pt-3 pb-2 sm:pb-3 bg-[#f8eddc]/60`}
+                  <Card
+                    className={`${quest.color} border-2 ${quest.borderColor} rounded-xl shadow-md overflow-hidden cursor-pointer w-full`}
+                    onClick={quest.onClick}
                   >
-                    <div className="flex flex-col sm:flex-row items-center w-full justify-between gap-2 sm:gap-0">
-                      <div className="text-xs sm:text-sm font-medium text-[#9b8e7e] flex items-center">
-                        <Music className="h-3 w-3 mr-1" /> ミッション No.
-                        {index + 1}
+                    <CardHeader className="pb-2 relative px-2 sm:px-4">
+                      <div className="absolute -top-0 -left-0 bg-white rounded-br-xl px-2 pt-1 pb-2 border-r-2 border-b-2 border-[#e4cbac]">
+                        <span className="text-xl">{quest.emoji}</span>
                       </div>
-                      <div className="bg-[#f8eddc] py-1 px-2 sm:px-3 rounded-full text-xs sm:text-sm text-[#7b6c5d] font-medium border border-[#e4cbac] flex items-center">
-                        <Star className="h-3 w-3 text-[#e38b31] mr-1" />
-                        {quest.reward}
+                      <div className="absolute top-1 right-2 bg-[#f8eddc] text-xs font-medium py-0.5 px-2 rounded-full border border-[#e4cbac]">
+                        {quest.difficulty}
                       </div>
+                      <CardTitle className="text-lg font-bold text-[#7b6c5d] mt-5 ml-2">
+                        {quest.title}
+                      </CardTitle>
+                      <CardDescription className="text-[#9b8e7e] ml-2">
+                        {quest.description}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex-1 min-h-[60px] sm:min-h-[80px] pb-2">
+                      <div className="flex justify-center items-center h-full">
+                        <div
+                          className={`${quest.iconBg} p-4 rounded-full border-2 ${quest.iconBorder} shadow-md flex items-center justify-center`}
+                        >
+                          {quest.icon}
+                        </div>
+                      </div>
+                    </CardContent>
+                    <CardFooter
+                      className={`border-t-2 border-[#e4cbac] pt-2 sm:pt-3 pb-2 sm:pb-3 bg-[#f8eddc]/60`}
+                    >
+                      <div className="flex flex-col sm:flex-row items-center w-full justify-between gap-2 sm:gap-0">
+                        <div className="text-xs sm:text-sm font-medium text-[#9b8e7e] flex items-center">
+                          <Music className="h-3 w-3 mr-1" /> ミッション No.
+                          {index + 1}
+                        </div>
+                        <div className="bg-[#f8eddc] py-1 px-2 sm:px-3 rounded-full text-xs sm:text-sm text-[#7b6c5d] font-medium border border-[#e4cbac] flex items-center">
+                          <Star className="h-3 w-3 text-[#e38b31] mr-1" />
+                          {quest.reward}
+                        </div>
+                      </div>
+                    </CardFooter>
+                  </Card>
+                  {activeCard === index && (
+                    <div className="absolute -bottom-2 right-3 transform animate-bounce-slow">
+                      <Heart className="h-5 w-5 text-[#f87171]" />
                     </div>
-                  </CardFooter>
-                </Card>
-                {activeCard === index && (
-                  <div className="absolute -bottom-2 right-3 transform animate-bounce-slow">
-                    <Heart className="h-5 w-5 text-[#f87171]" />
-                  </div>
-                )}
-              </div>
-            ))}
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* 運営への報告ボタン - メタ機能 */}
       {!isLoading && !error && (
         <>
-          <div className="mt-10 sm:mt-16 mb-4 sm:mb-6 flex items-center gap-2 sm:gap-3">
+          <div className="mt-10 sm:mt-16 mb-4 sm:mb-6 flex items-center gap-2 sm:gap-3 w-full max-w-2xl mx-auto">
             <div className="h-px bg-red-300 flex-grow"></div>
             <span className="text-sm font-medium text-red-600 bg-red-50 px-3 py-1 rounded-full border border-red-200">
               アプリサポート
@@ -696,7 +701,7 @@ export default function ProfilePage() {
             <div className="h-px bg-red-300 flex-grow"></div>
           </div>
 
-          <div className="flex justify-center">
+          <div className="flex justify-center w-full max-w-2xl mx-auto">
             <div className="relative transform hover:scale-105 transition-all duration-300 w-full max-w-md">
               <button
                 onClick={() => router.push("/reports/submit")}
@@ -727,7 +732,7 @@ export default function ProfilePage() {
             </div>
           </div>
 
-          <p className="text-center text-xs sm:text-sm text-red-600 font-medium mt-2 sm:mt-3 mb-2 sm:mb-4">
+          <p className="text-center text-xs sm:text-sm text-red-600 font-medium mt-2 sm:mt-3 mb-2 sm:mb-4 w-full max-w-2xl mx-auto">
             アプリの問題報告やご意見・ご要望はこちらからお願いします
           </p>
         </>


### PR DESCRIPTION
## やったこと
フロントでの表示の大きさを画面の大きさに対して設定しました
（主要なページのレスポンシブ対応は一通り完了）
### 対応済みページ
- /profile（プロフィール表示）
- /profile/edit（プロフィール編集）
- /myhouse（マイハウス/学習管理）
- /buildings（建物一覧・ショップ）

## 確認方法
1. cd frontend-nodejs
2. npm run build
3. npm run start
4. `http://localhost:3000/myhouse`
5. ipadなどでチャット画面やUIが崩れないことを確認してください。

## 共有事項
- 私自身、開発ツールで確認はしたのですが、ipad持っていないので確認していただけるとありがたいです。
- `http://localhost:3000` のアプリ最初の画面は今後このアプリに合ったUIに変更するので仮で作ってます。
- 次アプリ最初の画面作ります